### PR TITLE
Fixed a bug where urls followed by a newline would load incorrectly

### DIFF
--- a/GroupMeClient/ViewModels/Controls/Attachments/LinkAttachmentBaseViewModel.cs
+++ b/GroupMeClient/ViewModels/Controls/Attachments/LinkAttachmentBaseViewModel.cs
@@ -64,9 +64,13 @@ namespace GroupMeClient.ViewModels.Controls.Attachments
             {
                 this.url = value;
 
-                if (this.url.Contains(" "))
+                var stopAtCharacters = new string[] { " ", "\n" };
+                foreach (var stopChar in stopAtCharacters)
                 {
-                    this.url = this.url.Substring(0, this.url.IndexOf(" "));
+                    if (this.url.Contains(stopChar))
+                    {
+                        this.url = this.url.Substring(0, this.url.IndexOf(stopChar));
+                    }
                 }
 
                 if (Uri.TryCreate(this.url, UriKind.Absolute, out var uri))


### PR DESCRIPTION
Resolved a bug where URLs would be linked incorrectly. If a URL was followed by a newline and then additional text, the additional text would be concatenated on the end of the URL.