### PR TITLE
Fixed scrolling issues on the settings page

### DIFF
--- a/GroupMeClient/Views/SettingsView.xaml
+++ b/GroupMeClient/Views/SettingsView.xaml
@@ -85,13 +85,30 @@
 
                 <ListView
                     ItemsSource="{Binding Source={StaticResource ListBoxItems}}">
-
                     <ListView.View>
                         <GridView ColumnHeaderContainerStyle="{StaticResource MyColumnHeader}">
                             <GridViewColumn Header="Name" Width="300" DisplayMemberBinding="{Binding Name}" />
                             <GridViewColumn Header="Version" Width="70" DisplayMemberBinding="{Binding Version}" />
                         </GridView>
                     </ListView.View>
+                    
+                    <ListView.Template>
+                        <ControlTemplate>
+                            <ItemsPresenter></ItemsPresenter>
+                        </ControlTemplate>
+                    </ListView.Template>
+                    
+                    <ListView.ItemContainerStyle>
+                        <Style TargetType="ListViewItem">
+                            <Setter Property="Focusable" Value="False"/>
+                            <Style.Triggers>
+                                <Trigger Property="IsMouseOver" Value="True">
+                                    <Setter Property="Background" Value="Transparent" />
+                                    <Setter Property="BorderBrush" Value="Transparent" />
+                                </Trigger>
+                            </Style.Triggers>
+                        </Style>
+                    </ListView.ItemContainerStyle>
 
                     <ListView.GroupStyle>
                         <GroupStyle>


### PR DESCRIPTION
Previously, the Settings page could not be scrolled if the mouse was over the listing of installed plugins. The plugins listing has been improved to not interfere with scrolling, and to not highlight strangely when hovered over.