### PR TITLE
Support for a configurable number of MultiChats

### DIFF
--- a/GroupMeClient/Settings/UISettings.cs
+++ b/GroupMeClient/Settings/UISettings.cs
@@ -17,5 +17,17 @@ namespace GroupMeClient.Settings
         /// If enabled, preview versions will be shown. If disabled, full resolution versions will be shown instead.
         /// </summary>
         public bool ShowPreviewsForMultiImages { get; set; } = false;
+
+        /// <summary>
+        /// Gets or sets a value indicating the maximum number of chats that can be opened at any given time
+        /// when the program is in regular mode (with the full left sidebar displayed).
+        /// </summary>
+        public int MaximumNumberOfMultiChatsNormal { get; set; } = 3;
+
+        /// <summary>
+        /// Gets or sets a value indicating the maximum number of chats that can be opened at any given time
+        /// when the left sidebar is collapsed (minibar mode).
+        /// </summary>
+        public int MaximumNumberOfMultiChatsMinibar { get; set; } = 4;
     }
 }

--- a/GroupMeClient/ViewModels/ChatsViewModel.cs
+++ b/GroupMeClient/ViewModels/ChatsViewModel.cs
@@ -26,6 +26,7 @@ namespace GroupMeClient.ViewModels
     public class ChatsViewModel : ViewModelBase, INotificationSink
     {
         private string groupChatFilter = string.Empty;
+        private bool miniBarModeEnabled = false;
 
         /// <summary>
         /// Initializes a new instance of the <see cref="ChatsViewModel"/> class.
@@ -89,6 +90,22 @@ namespace GroupMeClient.ViewModels
             {
                 this.Set(() => this.GroupChatFilter, ref this.groupChatFilter, value);
                 this.SortedFilteredGroupChats.Refresh();
+            }
+        }
+
+        /// <summary>
+        /// Gets or sets a value indicating whether minibar mode is enabled.
+        /// </summary>
+        public bool MiniBarModeEnabled
+        {
+            get
+            {
+                return this.miniBarModeEnabled;
+            }
+
+            set
+            {
+                this.Set(() => this.MiniBarModeEnabled, ref this.miniBarModeEnabled, value);
             }
         }
 
@@ -271,8 +288,12 @@ namespace GroupMeClient.ViewModels
                 this.PublishTotalUnreadCount();
             }
 
-            // limit to three multi-chats at a time
-            while (this.ActiveGroupsChats.Count > 3)
+            // Limit to three multi-chats at a time
+            // But, only close a single chat. Users will not expect multiple
+            // chats to close at once. This could occur if the user opened several chats in MiniBar mode,
+            // and then switched back to regular mode.
+            var maximumChats = this.MiniBarModeEnabled ? this.SettingsManager.UISettings.MaximumNumberOfMultiChatsMinibar : this.SettingsManager.UISettings.MaximumNumberOfMultiChatsNormal;
+            if (this.ActiveGroupsChats.Count > maximumChats)
             {
                 var removeGroup = this.ActiveGroupsChats.Last();
                 this.PushClient.Unsubscribe(group.MessageContainer);

--- a/GroupMeClient/ViewModels/SettingsViewModel.cs
+++ b/GroupMeClient/ViewModels/SettingsViewModel.cs
@@ -56,6 +56,42 @@ namespace GroupMeClient.ViewModels
             }
         }
 
+        /// <summary>
+        /// Gets or sets a value indicating how many Multi-Chats are allowed in regular mode.
+        /// </summary>
+        public int MaximumNumberOfMultiChats
+        {
+            get
+            {
+                return this.SettingsManager.UISettings.MaximumNumberOfMultiChatsNormal;
+            }
+
+            set
+            {
+                this.SettingsManager.UISettings.MaximumNumberOfMultiChatsNormal = value;
+                this.RaisePropertyChanged(nameof(this.MaximumNumberOfMultiChats));
+                this.SettingsManager.SaveSettings();
+            }
+        }
+
+        /// <summary>
+        /// Gets or sets a value indicating how many Multi-Chats are allowed in MiniBar mode.
+        /// </summary>
+        public int MaximumNumberOfMultiChatsMiniBar
+        {
+            get
+            {
+                return this.SettingsManager.UISettings.MaximumNumberOfMultiChatsMinibar;
+            }
+
+            set
+            {
+                this.SettingsManager.UISettings.MaximumNumberOfMultiChatsMinibar = value;
+                this.RaisePropertyChanged(nameof(this.MaximumNumberOfMultiChatsMiniBar));
+                this.SettingsManager.SaveSettings();
+            }
+        }
+
         private Settings.SettingsManager SettingsManager { get; }
 
         private void LoadPluginInfo()

--- a/GroupMeClient/Views/ChatsView.xaml
+++ b/GroupMeClient/Views/ChatsView.xaml
@@ -67,6 +67,7 @@
                 </Grid.RowDefinitions>
 
                 <ToggleButton Grid.Column="0"
+                              IsChecked="{Binding MiniBarModeEnabled, Mode=TwoWay}"
                               HorizontalAlignment="Left" VerticalAlignment="Center"
                               Margin="15,0,0,0"
                               Height="Auto" FontSize="17" FontWeight="SemiBold"

--- a/GroupMeClient/Views/SettingsView.xaml
+++ b/GroupMeClient/Views/SettingsView.xaml
@@ -46,7 +46,20 @@
 
                 <StackPanel>
                     <CheckBox Content="Show Only Previews When Multiple Images Are Attached to a Single Message"
-                              IsChecked="{Binding ShowPreviewsForMultiImages, Mode=TwoWay}"/>
+                              IsChecked="{Binding ShowPreviewsForMultiImages, Mode=TwoWay}" Margin="0,5,0,0"/>
+
+                    <StackPanel Orientation="Horizontal" Margin="0,5,0,0">
+                        <Label Content="Maximum Number of Multi-Chats with Full Sidebar: " />
+                        <controls:NumericUpDown Minimum="1" Maximum="6" Width="30"
+                                                Value="{Binding MaximumNumberOfMultiChats}"/>
+                    </StackPanel>
+
+                    <StackPanel Orientation="Horizontal" Margin="0,5,0,0">
+                        <Label Content="Maximum Number of Multi-Chats in MiniBar Mode: " />
+                        <controls:NumericUpDown Minimum="1" Maximum="6" Width="30"
+                                                Value="{Binding MaximumNumberOfMultiChatsMiniBar}"/>
+                    </StackPanel>
+
                 </StackPanel>
             </GroupBox>
 


### PR DESCRIPTION
The number of MultiChats that can be opened (both in regular and MiniBar mode) can be configured in the settings menu