### PR TITLE
Added support for restoring application state after crash or reboot

### DIFF
--- a/GroupMeClient/GroupMeClient.csproj
+++ b/GroupMeClient/GroupMeClient.csproj
@@ -79,6 +79,7 @@
     <Compile Include="Messaging\IndexAndRunPluginRequestMessage.cs" />
     <Compile Include="Messaging\DisconnectedRequestMessage.cs" />
     <Compile Include="Native\WindowsThemeUtils.cs" />
+    <Compile Include="Native\RecoveryManager.cs" />
     <Compile Include="Notifications\Display\WpfToast\ToastHolder.xaml.cs">
       <DependentUpon>ToastHolder.xaml</DependentUpon>
     </Compile>

--- a/GroupMeClient/Native/RecoveryManager.cs
+++ b/GroupMeClient/Native/RecoveryManager.cs
@@ -1,0 +1,72 @@
+﻿using System;
+using System.Diagnostics;
+using System.Reflection;
+using System.Runtime.InteropServices;
+
+namespace GroupMeClient.Native
+{
+    /// <summary>
+    /// <see cref="RecoveryManager"/> provides support for Windows Error Recovery automatic application restart.
+    /// </summary>
+    /// <remarks>
+    /// Adapted from https://stackoverflow.com/questions/32520036/restart-a-crashed-program-with-registerapplicationrestart-without-user-prompt.
+    /// </remarks>
+    public class RecoveryManager
+    {
+        /// <summary>
+        /// Defines a delegate for callbacks after a Windows Recovery event occurs.
+        /// </summary>
+        /// <param name="parameter">Context information specified for recovery.</param>
+        /// <returns>The return value is not used and should be 0.</returns>
+        public delegate int RecoveryDelegate(IntPtr parameter);
+
+        /// <summary>
+        /// Gets the command line argument that is used to indicate that an expected restart has occured.
+        /// </summary>
+        public static string RestartCommandLine => "/restart";
+
+        [DllImport("kernel32.dll")]
+        private static extern int RegisterApplicationRecoveryCallback(
+                RecoveryDelegate recoveryCallback,
+                IntPtr parameter,
+                uint pingInterval,
+                uint flags);
+
+        [DllImport("kernel32.dll")]
+        private static extern void ApplicationRecoveryFinished(bool success);
+
+        [DllImport("kernel32.dll", SetLastError = true)]
+        private static extern int RegisterApplicationRestart(
+            [MarshalAs(UnmanagedType.LPWStr)] string commandLineArgs, 
+            int flags);
+
+        /// <summary>
+        /// Enables Windows Error Recovery automatic recovery.
+        /// Recovery allows for immediately resuming an application after a crash or hang occurs.
+        /// </summary>
+        public static void RegisterForRecovery()
+        {
+            var callback = new RecoveryDelegate(p =>
+            {
+                Process.Start(Assembly.GetEntryAssembly().Location, RestartCommandLine);
+                ApplicationRecoveryFinished(true);
+                return 0;
+            });
+
+            var interval = 100U;
+            var flags = 0U;
+
+            var result = RegisterApplicationRecoveryCallback(callback, IntPtr.Zero, interval, flags);
+        }
+
+        /// <summary>
+        /// Enables Windows Error Recovery automatic restart.
+        /// Marking this application as WER aware also allows for automatic application restart after system updates or reboot.
+        /// For more information, see https://docs.microsoft.com/en-us/windows/win32/recovery/registering-for-application-restart.
+        /// </summary>
+        public static void RegisterForRestart()
+        {
+            RegisterApplicationRestart(RestartCommandLine, 0);
+        }
+    }
+}

--- a/GroupMeClient/Settings/ChatsSettings.cs
+++ b/GroupMeClient/Settings/ChatsSettings.cs
@@ -18,6 +18,11 @@ namespace GroupMeClient.Settings
         public List<GroupOrChatState> GroupChatStates { get; set; } = new List<GroupOrChatState>();
 
         /// <summary>
+        /// Gets or sets a list of the Group or Chat IDs for all currently opened chats.
+        /// </summary>
+        public List<string> OpenChats { get; set; } = new List<string>();
+
+        /// <summary>
         /// <see cref="GroupOrChatState"/> saves the state of a specific <see cref="GroupMeClientApi.Models.Group"/>
         /// or <see cref="GroupMeClientApi.Models.Chat"/>.
         /// </summary>

--- a/GroupMeClient/ViewModels/MainViewModel.cs
+++ b/GroupMeClient/ViewModels/MainViewModel.cs
@@ -202,6 +202,9 @@ namespace GroupMeClient.ViewModels
 
             this.UpdateAssist = new UpdateAssist();
             Application.Current.MainWindow.Closing += new CancelEventHandler(this.MainWindow_Closing);
+
+            Native.RecoveryManager.RegisterForRecovery();
+            Native.RecoveryManager.RegisterForRestart();
         }
 
         private void RegisterNotifications()


### PR DESCRIPTION
Support for Windows 10 automatic restore.
If Windows reboots for updates, GroupMe will open back up on boot and restore all opened chats.
If GroupMe crashes, the application will automatically restore as well.