### PR TITLE
Feature/fix mention bug

### DIFF
--- a/GroupMeClient/ViewModels/Controls/MessageControlViewModel.cs
+++ b/GroupMeClient/ViewModels/Controls/MessageControlViewModel.cs
@@ -478,6 +478,7 @@ namespace GroupMeClient.ViewModels.Controls
                 inlinesTemp.Add(new Run(text));
             }
 
+            // Remove any hidden text
             inlinesTemp.RemoveAll(x =>
             {
                 if (x is Run r)

--- a/GroupMeClient/ViewModels/Controls/MessageControlViewModel.cs
+++ b/GroupMeClient/ViewModels/Controls/MessageControlViewModel.cs
@@ -450,11 +450,6 @@ namespace GroupMeClient.ViewModels.Controls
         {
             var text = this.Message.Text ?? string.Empty;
 
-            if (!string.IsNullOrEmpty(this.HiddenText))
-            {
-                text = text.Replace(this.HiddenText, string.Empty);
-            }
-
             var inlinesTemp = new List<Inline>();
             var inlinesResult = new List<Inline>();
 
@@ -482,6 +477,18 @@ namespace GroupMeClient.ViewModels.Controls
             {
                 inlinesTemp.Add(new Run(text));
             }
+
+            inlinesTemp.RemoveAll(x =>
+            {
+                if (x is Run r)
+                {
+                    return r.Text.Trim() == this.HiddenText;
+                }
+                else
+                {
+                    return false;
+                }
+            });
 
             // Process Hyperlinks
             foreach (var part in inlinesTemp)


### PR DESCRIPTION
Certain message formats including mentions could cause a crash. Items that are included as GroupMe Attachments, but also have a URL directly embedded in the message text (such as videos) previously were not compatible with including mentions. 