### PR TITLE
Updated to Entity Framework Core 3.1 and new SQLite bundle

### DIFF
--- a/GroupMeClient/GroupMeClient.csproj
+++ b/GroupMeClient/GroupMeClient.csproj
@@ -386,11 +386,8 @@
     <PackageReference Include="MahApps.Metro.IconPacks">
       <Version>2.3.0</Version>
     </PackageReference>
-    <PackageReference Include="Microsoft.EntityFrameworkCore">
-      <Version>2.2.6</Version>
-    </PackageReference>
     <PackageReference Include="Microsoft.EntityFrameworkCore.Sqlite">
-      <Version>2.2.6</Version>
+      <Version>3.1.1</Version>
     </PackageReference>
     <PackageReference Include="Microsoft.Toolkit.Uwp.Notifications">
       <Version>6.0.0</Version>
@@ -405,9 +402,6 @@
       <Version>5.4.0</Version>
       <IncludeAssets>runtime; build; native; contentfiles; analyzers; buildtransitive</IncludeAssets>
       <PrivateAssets>all</PrivateAssets>
-    </PackageReference>
-    <PackageReference Include="SQLitePCLRaw.bundle_green">
-      <Version>1.1.14</Version>
     </PackageReference>
     <PackageReference Include="Squirrel.Windows">
       <Version>1.9.1</Version>

--- a/GroupMeClient/ViewModels/SearchViewModel.cs
+++ b/GroupMeClient/ViewModels/SearchViewModel.cs
@@ -446,9 +446,11 @@ namespace GroupMeClient.ViewModels
             var filteredMessages = Enumerable.Empty<Message>().AsQueryable();
             var filtersApplied = false;
 
+            // TODO: Can we disable Client Side evaluation for filters? Breaking change in Entity Framework Core 3
+            // Enabling filters will be a lot faster if we can.
             if (this.FilterHasAttachedImage)
             {
-                var messagesWithImages = results
+                var messagesWithImages = results.AsEnumerable()
                     .Where(m => m.Attachments.OfType<ImageAttachment>().Count() >= 1);
 
                 filteredMessages = filteredMessages.Union(messagesWithImages);
@@ -457,7 +459,7 @@ namespace GroupMeClient.ViewModels
 
             if (this.FilterHasAttachedLinkedImage)
             {
-                var messagesWithLinkedImages = results
+                var messagesWithLinkedImages = results.AsEnumerable()
                     .Where(m => m.Attachments.OfType<LinkedImageAttachment>().Count() >= 1);
 
                 filteredMessages = filteredMessages.Union(messagesWithLinkedImages);
@@ -466,7 +468,7 @@ namespace GroupMeClient.ViewModels
 
             if (this.FilterHasAttachedVideo)
             {
-                var messagesWithVideos = results
+                var messagesWithVideos = results.AsEnumerable()
                     .Where(m => m.Attachments.OfType<VideoAttachment>().Count() >= 1);
 
                 filteredMessages = filteredMessages.Union(messagesWithVideos);
@@ -475,7 +477,7 @@ namespace GroupMeClient.ViewModels
 
             if (this.FilterHasAttachedMentions)
             {
-                var messagesWithMentions = results
+                var messagesWithMentions = results.AsEnumerable()
                     .Where(m => m.Attachments.OfType<MentionsAttachment>().Count() >= 1);
 
                 filteredMessages = filteredMessages.Union(messagesWithMentions);


### PR DESCRIPTION
Entity Framework Core 3.1 has restored support for traditional .NET Framework.