### PR TITLE
Fix for crashing when enabling the document search filter

### DIFF
--- a/GroupMeClient/ViewModels/SearchViewModel.cs
+++ b/GroupMeClient/ViewModels/SearchViewModel.cs
@@ -488,7 +488,7 @@ namespace GroupMeClient.ViewModels
 
             if (this.FilterHasAttachedDocument)
             {
-                var messagesWithDocuments = results
+                var messagesWithDocuments = results.AsEnumerable()
                     .Where(m => m.Attachments.OfType<FileAttachment>().Count() >= 1);
 
                 filteredMessages = filteredMessages.Union(messagesWithDocuments);


### PR DESCRIPTION
Resolves a crash when using document filters introduced by upgrading to EF Core 3