### PR TITLE
Fixed a crash that occured when opening GroupMe 

### DIFF
--- a/GroupMeClient/ViewModels/MainViewModel.cs
+++ b/GroupMeClient/ViewModels/MainViewModel.cs
@@ -216,7 +216,13 @@ namespace GroupMeClient.ViewModels
             {
                 foreach (var file in Directory.EnumerateFiles(tempFolder))
                 {
-                    File.Delete(file);
+                    try
+                    {
+                        File.Delete(file);
+                    }
+                    catch (Exception)
+                    {
+                    }
                 }
             }
 


### PR DESCRIPTION
Resolved an issue where having a previously downloaded attachment opened and locked in MS Office would cause a crash when opening GMDC and attempting to clean up temp files.