### PR TITLE
Added support for checking the length of a message

### DIFF
--- a/GroupMeClient/Extensions/MultiLineSendBox.cs
+++ b/GroupMeClient/Extensions/MultiLineSendBox.cs
@@ -1,6 +1,7 @@
 ﻿using System.Windows;
 using System.Windows.Controls;
 using System.Windows.Input;
+using System.Windows.Media;
 
 namespace GroupMeClient.Extensions
 {
@@ -11,10 +12,35 @@ namespace GroupMeClient.Extensions
     public class MultiLineSendBox : TextBox
     {
         /// <summary>
+        /// The maximum message size, in characters, that can be sent.
+        /// </summary>
+        public const int MaximumMessageLength = 1000;
+
+        /// <summary>
         /// Gets a RoutedEvent for when Send is invoked on this <see cref="MultiLineSendBox"/>.
         /// </summary>
         public static readonly RoutedEvent SendEvent = EventManager.RegisterRoutedEvent(
             "Send", RoutingStrategy.Direct, typeof(RoutedEventHandler), typeof(MultiLineSendBox));
+
+        /// <summary>
+        /// Gets a dependency property for the <see cref="Brush"/> used to render the text.
+        /// </summary>
+        public static readonly DependencyProperty RegularTextBrushProperty =
+            DependencyProperty.Register(
+                "RegularTextBrush",
+                typeof(Brush),
+                typeof(MultiLineSendBox),
+                new PropertyMetadata(default(Brush), new PropertyChangedCallback(OnBrushChanged)));
+
+        /// <summary>
+        /// Gets a dependency property for the <see cref="Brush"/> used to render the text when a validation error has occured.
+        /// </summary>
+        public static readonly DependencyProperty ErrorTextBrushProperty =
+            DependencyProperty.Register(
+                "ErrorTextBrush",
+                typeof(Brush),
+                typeof(MultiLineSendBox),
+                new PropertyMetadata(default(Brush), new PropertyChangedCallback(OnBrushChanged)));
 
         /// <summary>
         /// Initializes a new instance of the <see cref="MultiLineSendBox"/> class.
@@ -22,6 +48,7 @@ namespace GroupMeClient.Extensions
         public MultiLineSendBox()
         {
             this.KeyDown += this.TextBoxKeyDown;
+            this.TextChanged += this.MultiLineSendBox_TextChanged;
             this.PreviewKeyDown += this.TextBoxPreviewKeyDown;
         }
 
@@ -32,6 +59,44 @@ namespace GroupMeClient.Extensions
         {
             add { this.AddHandler(SendEvent, value); }
             remove { this.RemoveHandler(SendEvent, value); }
+        }
+
+        /// <summary>
+        /// Gets or sets which brush will be used to render the text when no validation errors occur.
+        /// </summary>
+        public Brush RegularTextBrush
+        {
+            get { return (Brush)this.GetValue(RegularTextBrushProperty); }
+            set { this.SetValue(RegularTextBrushProperty, value); }
+        }
+
+        /// <summary>
+        /// Gets or sets the brush that will be used to render the text when validation errors occur.
+        /// </summary>
+        public Brush ErrorTextBrush
+        {
+            get { return (Brush)this.GetValue(ErrorTextBrushProperty); }
+            set { this.SetValue(ErrorTextBrushProperty, value); }
+        }
+
+        private static void OnBrushChanged(DependencyObject d, DependencyPropertyChangedEventArgs e)
+        {
+            if (d is MultiLineSendBox mlsb)
+            {
+                mlsb.MultiLineSendBox_TextChanged(mlsb, null);
+            }
+        }
+
+        private void MultiLineSendBox_TextChanged(object sender, TextChangedEventArgs e)
+        {
+            if (this.Text.Length > MaximumMessageLength)
+            {
+                this.Foreground = this.ErrorTextBrush;
+            }
+            else
+            {
+                this.Foreground = this.RegularTextBrush;
+            }
         }
 
         private void TextBoxKeyDown(object sender, KeyEventArgs e)

--- a/GroupMeClient/Views/Controls/GroupContentsControl.xaml
+++ b/GroupMeClient/Views/Controls/GroupContentsControl.xaml
@@ -340,6 +340,8 @@
                 BorderBrush="Transparent"
                 BorderThickness="0"
                 FontSize="15"
+                RegularTextBrush="{DynamicResource TextBrush}"
+                ErrorTextBrush="Red"
                 AcceptsReturn="True"
                 TextWrapping="Wrap"
                 Controls:TextBoxHelper.Watermark="Send a Message..."

--- a/GroupMeClient/Views/Controls/MessageEffectsControl.xaml
+++ b/GroupMeClient/Views/Controls/MessageEffectsControl.xaml
@@ -104,6 +104,8 @@
                 BorderBrush="Transparent"
                 BorderThickness="0"
                 FontSize="15"
+                RegularTextBrush="{DynamicResource TextBrush}"
+                ErrorTextBrush="Red"
                 MinHeight="49"
                 HorizontalAlignment="Stretch"
                 VerticalAlignment="Center"

--- a/GroupMeClient/Views/Controls/SendFileControl.xaml
+++ b/GroupMeClient/Views/Controls/SendFileControl.xaml
@@ -70,6 +70,8 @@
                 BorderBrush="Transparent"
                 BorderThickness="0"
                 FontSize="15"
+                RegularTextBrush="{DynamicResource TextBrush}"
+                ErrorTextBrush="Red"
                 MinHeight="49"
                 HorizontalAlignment="Stretch"
                 VerticalAlignment="Center"

--- a/GroupMeClient/Views/Controls/SendImageControl.xaml
+++ b/GroupMeClient/Views/Controls/SendImageControl.xaml
@@ -57,6 +57,8 @@
                 BorderBrush="Transparent"
                 BorderThickness="0"
                 FontSize="15"
+                RegularTextBrush="{DynamicResource TextBrush}"
+                ErrorTextBrush="Red"
                 MinHeight="49"
                 HorizontalAlignment="Stretch"
                 VerticalAlignment="Center"

--- a/GroupMeClient/Views/Controls/ViewImageControl.xaml
+++ b/GroupMeClient/Views/Controls/ViewImageControl.xaml
@@ -8,7 +8,6 @@
              xmlns:iconPacks="http://metro.mahapps.com/winfx/xaml/iconpacks"
              xmlns:extensions="clr-namespace:GroupMeClient.Extensions"
              xmlns:converters="clr-namespace:GroupMeClient.Converters"
-             xmlns:behaviors="http://schemas.microsoft.com/xaml/behaviors"
              mc:Ignorable="d" 
              d:DesignHeight="200" d:DesignWidth="200"
              Background="Transparent">


### PR DESCRIPTION
Messages that exceed the maximum allowable length (per GroupMe) will be rendered in red text to provide feedback prior to attempting to send it.