### PR TITLE
Fixed a bug where text following a URL would not be shown in a message

### DIFF
--- a/GroupMeClient/ViewModels/Controls/MessageControlViewModel.cs
+++ b/GroupMeClient/ViewModels/Controls/MessageControlViewModel.cs
@@ -522,7 +522,7 @@ namespace GroupMeClient.ViewModels.Controls
 
                         if (index + this.HiddenText.Length != r.Text.Length)
                         {
-                            var after = new Run(r.Text.Substring(index + r.Text.Length));
+                            var after = new Run(r.Text.Substring(index + this.HiddenText.Length));
                             inlinesResult.Add(after);
                         }
                     }


### PR DESCRIPTION
Fixed an issue where messages containing a URL would have any text after the URL truncated.