### PR TITLE
Feature/unknown attachment support

### DIFF
--- a/GroupMeClient/ViewModels/Controls/Attachments/FileAttachmentControlViewModel.cs
+++ b/GroupMeClient/ViewModels/Controls/Attachments/FileAttachmentControlViewModel.cs
@@ -77,7 +77,7 @@ namespace GroupMeClient.ViewModels.Controls.Attachments
             {
                 this.IsLoading = true;
                 var data = await this.FileAttachment.DownloadFileAsync(this.MessageContainer.Messages.First());
-                var extension = FileAttachment.GroupMeDocumentMimeTypeMapper.MimeTypeToExtension(this.FileData.MimeType);
+                var extension = System.IO.Path.GetExtension(this.FileData.FileName);
                 var tempFileName = Path.GetFileNameWithoutExtension(Path.GetTempFileName());
                 var tempFile = Path.Combine(Path.GetTempPath(), "GroupMeDesktopClient", tempFileName + extension);
                 File.WriteAllBytes(tempFile, data);

--- a/GroupMeClient/ViewModels/Controls/GroupContentsControlViewModel.cs
+++ b/GroupMeClient/ViewModels/Controls/GroupContentsControlViewModel.cs
@@ -291,6 +291,12 @@ namespace GroupMeClient.ViewModels.Controls
                     this.ShowFileSendDialog(file);
                     break;
                 }
+                else
+                {
+                    // Allow sending unsupported files anyway if they drag-drop them
+                    this.ShowFileSendDialog(file);
+                    break;
+                }
             }
         }
 


### PR DESCRIPTION
Support for sending any type of document by drag-dropping it into the chat area. Fixed a related crash when trying to open documents with a MIME type not recognized by GroupMe.