### PR TITLE
Feature/improved paste features

### DIFF
--- a/GroupMeClient/Extensions/FileDragDropHelper.cs
+++ b/GroupMeClient/Extensions/FileDragDropHelper.cs
@@ -1,5 +1,6 @@
 ﻿using System;
 using System.IO;
+using System.Linq;
 using System.Windows;
 using System.Windows.Controls;
 using System.Windows.Input;
@@ -168,21 +169,27 @@ namespace GroupMeClient.Extensions
                     imageBytes = Utilities.ImageUtils.BitmapSourceToBytes(image);
                 }
 
+                if (!(sender is DependencyObject d))
+                {
+                    return;
+                }
+
+                var target = d.GetValue(FileDragDropTargetProperty);
+                if (!(target is IDragDropTarget fileTarget))
+                {
+                    throw new Exception("FileDragDropTarget object must be of type IFileDragDropTarget");
+                }
+
                 if (imageBytes != null)
                 {
-                    if (!(sender is DependencyObject d))
-                    {
-                        return;
-                    }
-
-                    var target = d.GetValue(FileDragDropTargetProperty);
-                    if (!(target is IDragDropTarget fileTarget))
-                    {
-                        throw new Exception("FileDragDropTarget object must be of type IFileDragDropTarget");
-                    }
-
+                    // Handle pasting of all image data
                     fileTarget.OnImageDrop(imageBytes);
                     e.Handled = true;
+                }
+                else if (Clipboard.ContainsFileDropList())
+                {
+                    // Handle pasting of all file data
+                    fileTarget.OnFileDrop(Clipboard.GetFileDropList().Cast<string>().ToArray());
                 }
             }
         }

--- a/GroupMeClient/Extensions/FileDragDropHelper.cs
+++ b/GroupMeClient/Extensions/FileDragDropHelper.cs
@@ -137,6 +137,13 @@ namespace GroupMeClient.Extensions
             {
                 byte[] imageBytes = null;
 
+                if (Keyboard.IsKeyDown(Key.LeftShift) || Keyboard.IsKeyDown(Key.RightShift))
+                {
+                    // If Shift key is held, paste as plain-text, not an image.
+                    e.Handled = false;
+                    return;
+                }
+
                 // First check to see if "PNG" data is on the clipboard to preserve transparency
                 if (Clipboard.ContainsData("PNG"))
                 {

--- a/GroupMeClient/Extensions/FileDragDropPasteHelper.cs
+++ b/GroupMeClient/Extensions/FileDragDropPasteHelper.cs
@@ -9,29 +9,29 @@ using System.Windows.Media.Imaging;
 namespace GroupMeClient.Extensions
 {
     /// <summary>
-    /// FileDragDropHelper.
+    /// <see cref="FileDragDropPasteHelper"/> provides support for dragging and pasting files and images onto controls.
     /// </summary>
-    public class FileDragDropHelper
+    public class FileDragDropPasteHelper
     {
         /// <summary>
         /// Gets a property indicating if FileDragDrop is supported.
         /// </summary>
-        public static readonly DependencyProperty IsFileDragDropEnabledProperty =
-              DependencyProperty.RegisterAttached("IsFileDragDropEnabled", typeof(bool), typeof(FileDragDropHelper), new PropertyMetadata(OnFileDragDropEnabled));
+        public static readonly DependencyProperty IsFileDragDropPasteEnabledProperty =
+              DependencyProperty.RegisterAttached("IsFileDragDropPasteEnabled", typeof(bool), typeof(FileDragDropPasteHelper), new PropertyMetadata(OnFileDragDropPasteEnabled));
 
         /// <summary>
         /// Gets a property containing the File Drag Drop handler target.
         /// </summary>
-        public static readonly DependencyProperty FileDragDropTargetProperty =
-                DependencyProperty.RegisterAttached("FileDragDropTarget", typeof(object), typeof(FileDragDropHelper), null);
+        public static readonly DependencyProperty FileDragDropPasteTargetProperty =
+                DependencyProperty.RegisterAttached("FileDragDropPasteTarget", typeof(object), typeof(FileDragDropPasteHelper), null);
 
         /// <summary>
-        /// <see cref="IDragDropTarget"/> enables receiving updates when data is dropped onto a control.
+        /// <see cref="IDragDropPasteTarget"/> enables receiving updates when data is dropped onto a control.
         /// </summary>
         /// <remarks>
         /// Adapted from https://stackoverflow.com/a/37608994.
         /// </remarks>
-        public interface IDragDropTarget
+        public interface IDragDropPasteTarget
         {
             /// <summary>
             /// Executed when a file has been dragged onto the target.
@@ -47,46 +47,46 @@ namespace GroupMeClient.Extensions
         }
 
         /// <summary>
-        /// Gets a value indicating whether File Drag Drop is supported.
+        /// Gets a value indicating whether File Drag Drop and Enhanced Object Pasting are supported.
         /// </summary>
         /// <param name="obj">The dependency object to retreive the property from.</param>
         /// <returns>A boolean indicating whether enabled.</returns>
-        public static bool GetIsFileDragDropEnabled(DependencyObject obj)
+        public static bool GetIsFileDragDropPasteEnabled(DependencyObject obj)
         {
-            return (bool)obj.GetValue(IsFileDragDropEnabledProperty);
+            return (bool)obj.GetValue(IsFileDragDropPasteEnabledProperty);
         }
 
         /// <summary>
-        /// Sets a value indicating whether File Drag Drop is supported.
+        /// Sets a value indicating whether File Drag Drop and Enhanced Object Pasting are supported.
         /// </summary>
         /// <param name="obj">The dependency object to retreive the property from.</param>
-        /// <param name="value">Whether drag drop is supported.</param>
-        public static void SetIsFileDragDropEnabled(DependencyObject obj, bool value)
+        /// <param name="value">Whether drag drop and paste are supported.</param>
+        public static void SetIsFileDragDropPasteEnabled(DependencyObject obj, bool value)
         {
-            obj.SetValue(IsFileDragDropEnabledProperty, value);
+            obj.SetValue(IsFileDragDropPasteEnabledProperty, value);
         }
 
         /// <summary>
-        /// Gets a value containing the Drag Drop target.
+        /// Gets a value containing the Drag Drop Paste target.
         /// </summary>
         /// <param name="obj">The dependency object to retreive the property from.</param>
-        /// <returns>The drag drop target.</returns>
-        public static bool GetFileDragDropTarget(DependencyObject obj)
+        /// <returns>The drag drop paste target.</returns>
+        public static bool GetFileDragDropPasteTarget(DependencyObject obj)
         {
-            return (bool)obj.GetValue(FileDragDropTargetProperty);
+            return (bool)obj.GetValue(FileDragDropPasteTargetProperty);
         }
 
         /// <summary>
-        /// Sets the drag drop target.
+        /// Sets the drag drop paste target.
         /// </summary>
         /// <param name="obj">The dependency object to retreive the property from.</param>
         /// <param name="value">The target to assign.</param>
-        public static void SetFileDragDropTarget(DependencyObject obj, bool value)
+        public static void SetFileDragDropPasteTarget(DependencyObject obj, bool value)
         {
-            obj.SetValue(FileDragDropTargetProperty, value);
+            obj.SetValue(FileDragDropPasteTargetProperty, value);
         }
 
-        private static void OnFileDragDropEnabled(DependencyObject d, DependencyPropertyChangedEventArgs e)
+        private static void OnFileDragDropPasteEnabled(DependencyObject d, DependencyPropertyChangedEventArgs e)
         {
             if (e.NewValue == e.OldValue)
             {
@@ -109,8 +109,8 @@ namespace GroupMeClient.Extensions
                 return;
             }
 
-            var target = d.GetValue(FileDragDropTargetProperty);
-            if (target is IDragDropTarget fileTarget)
+            var target = d.GetValue(FileDragDropPasteTargetProperty);
+            if (target is IDragDropPasteTarget fileTarget)
             {
                 if (dragEventArgs.Data.GetDataPresent(DataFormats.FileDrop))
                 {
@@ -174,8 +174,8 @@ namespace GroupMeClient.Extensions
                     return;
                 }
 
-                var target = d.GetValue(FileDragDropTargetProperty);
-                if (!(target is IDragDropTarget fileTarget))
+                var target = d.GetValue(FileDragDropPasteTargetProperty);
+                if (!(target is IDragDropPasteTarget fileTarget))
                 {
                     throw new Exception("FileDragDropTarget object must be of type IFileDragDropTarget");
                 }

--- a/GroupMeClient/Extensions/MultiLineSendBox.cs
+++ b/GroupMeClient/Extensions/MultiLineSendBox.cs
@@ -50,6 +50,10 @@ namespace GroupMeClient.Extensions
             this.KeyDown += this.TextBoxKeyDown;
             this.TextChanged += this.MultiLineSendBox_TextChanged;
             this.PreviewKeyDown += this.TextBoxPreviewKeyDown;
+
+            var gesture = new KeyGesture(Key.V, ModifierKeys.Shift | ModifierKeys.Control);
+            var customPaste = new InputBinding(ApplicationCommands.Paste, gesture);
+            this.InputBindings.Add(customPaste);
         }
 
         /// <summary>

--- a/GroupMeClient/GroupMeClient.csproj
+++ b/GroupMeClient/GroupMeClient.csproj
@@ -91,7 +91,7 @@
     <Compile Include="Extensions\SelectableTextBlock.cs" />
     <Compile Include="Extensions\TextBlockExtensions.cs" />
     <Compile Include="Extensions\EventFocusAttachment.cs" />
-    <Compile Include="Extensions\FileDragDropHelper.cs" />
+    <Compile Include="Extensions\FileDragDropPasteHelper.cs" />
     <Compile Include="Utilities\ImageUtils.cs" />
     <Compile Include="Converters\InverseBoolConverter.cs" />
     <Compile Include="Converters\IsZeroConverter.cs" />

--- a/GroupMeClient/ViewModels/Controls/GroupContentsControlViewModel.cs
+++ b/GroupMeClient/ViewModels/Controls/GroupContentsControlViewModel.cs
@@ -22,7 +22,7 @@ namespace GroupMeClient.ViewModels.Controls
     /// <see cref="GroupContentsControlViewModel"/> provides a ViewModel for the <see cref="Views.Controls.GroupContentsControl"/> control that displays the contents (messages) of a Group or Chat.
     /// Controls for sending messages are also included.
     /// </summary>
-    public class GroupContentsControlViewModel : ViewModelBase, FileDragDropHelper.IDragDropTarget, IDisposable
+    public class GroupContentsControlViewModel : ViewModelBase, FileDragDropPasteHelper.IDragDropPasteTarget, IDisposable
     {
         private IMessageContainer messageContainer;
         private AvatarControlViewModel topBarAvatar;
@@ -274,7 +274,7 @@ namespace GroupMeClient.ViewModels.Controls
         }
 
         /// <inheritdoc />
-        void FileDragDropHelper.IDragDropTarget.OnFileDrop(string[] filepaths)
+        void FileDragDropPasteHelper.IDragDropPasteTarget.OnFileDrop(string[] filepaths)
         {
             var supportedImageExtensions = GroupMeClientApi.Models.Attachments.ImageAttachment.SupportedExtensions.ToList();
             var supportedFileExtensions = GroupMeClientApi.Models.Attachments.FileAttachment.GroupMeDocumentMimeTypeMapper.SupportedExtensions.ToList();
@@ -301,7 +301,7 @@ namespace GroupMeClient.ViewModels.Controls
         }
 
         /// <inheritdoc />
-        void FileDragDropHelper.IDragDropTarget.OnImageDrop(byte[] image)
+        void FileDragDropPasteHelper.IDragDropPasteTarget.OnImageDrop(byte[] image)
         {
             var memoryStream = new MemoryStream(image);
             this.ShowImageSendDialog(memoryStream);

--- a/GroupMeClient/Views/Controls/GroupContentsControl.xaml
+++ b/GroupMeClient/Views/Controls/GroupContentsControl.xaml
@@ -158,8 +158,8 @@
             extensions:ListBoxExtensions.AutoScrollToEnd="True"
             extensions:ListBoxExtensions.ScrollToTop="{Binding ReloadView}"
             AllowDrop="True"
-            extensions:FileDragDropHelper.IsFileDragDropEnabled="True"
-            extensions:FileDragDropHelper.FileDragDropTarget="{Binding}"
+            extensions:FileDragDropPasteHelper.IsFileDragDropPasteEnabled="True"
+            extensions:FileDragDropPasteHelper.FileDragDropPasteTarget="{Binding}"
             x:Name="messagesList">
 
             <ListBox.ItemContainerStyle>
@@ -346,8 +346,8 @@
                 TextWrapping="Wrap"
                 Controls:TextBoxHelper.Watermark="Send a Message..."
                 Text="{Binding Path=TypedMessageContents, Mode=TwoWay, UpdateSourceTrigger=PropertyChanged}"
-                extensions:FileDragDropHelper.IsFileDragDropEnabled="True"
-                extensions:FileDragDropHelper.FileDragDropTarget="{Binding}"
+                extensions:FileDragDropPasteHelper.IsFileDragDropPasteEnabled="True"
+                extensions:FileDragDropPasteHelper.FileDragDropPasteTarget="{Binding}"
                 SpellCheck.IsEnabled="True">
 
                 <behaviors:Interaction.Triggers>


### PR DESCRIPTION
The Control-Shift-V gesture will force paste unformatted text, regardless of other formatted data that may be on the clipboard. This is useful for many Microsoft Office Application, such as Excel which copies cells as a photo, CSV data, and as raw text. This functionality can also be invoked by holding shift while clicking paste.
Added support for pasting files from Windows Explorer for sending