### PR TITLE
Feature/support for sending files open in OneDrive

### DIFF
--- a/GroupMeClient/GroupMeClient.csproj
+++ b/GroupMeClient/GroupMeClient.csproj
@@ -122,6 +122,7 @@
     <Compile Include="Settings\SettingsManager.cs" />
     <Compile Include="Settings\UISettings.cs" />
     <Compile Include="Utilities\ReliabilityStateMachine.cs" />
+    <Compile Include="Utilities\TempFileUtils.cs" />
     <Compile Include="ViewModels\ChatsViewModel.cs" />
     <Compile Include="ViewModels\Controls\Attachments\GroupMeImageAttachmentControlViewModel.cs" />
     <Compile Include="ViewModels\Controls\Attachments\ImageLinkAttachmentControlViewModel.cs" />

--- a/GroupMeClient/Utilities/TempFileUtils.cs
+++ b/GroupMeClient/Utilities/TempFileUtils.cs
@@ -1,0 +1,54 @@
+﻿using System;
+using System.IO;
+
+namespace GroupMeClient.Utilities
+{
+    /// <summary>
+    /// <see cref="TempFileUtils"/> provides support for working with temporary storage in GroupMe Desktop Client.
+    /// </summary>
+    public class TempFileUtils
+    {
+        /// <summary>
+        /// Gets the default temporary folder in which data should be stored.
+        /// </summary>
+        public static string GroupMeDesktopClientTempFolder => Path.Combine(Path.GetTempPath(), "GroupMeDesktopClient");
+
+        /// <summary>
+        /// Gets a temporary file name that resides within the GroupMe Desktop Client temp directory.
+        /// Entries in this folder are automatically cleaned up by the application.
+        /// </summary>
+        /// <param name="originalFileName">A filename to base the temporary file extension on.</param>
+        /// <returns>A temporary file name. The temp file is not created on disk.</returns>
+        public static string GetTempFileName(string originalFileName)
+        {
+            var extension = Path.GetExtension(originalFileName);
+            var tempFileName = Path.GetFileNameWithoutExtension(Path.GetTempFileName());
+            var tempFile = Path.Combine(Path.GetTempPath(), "GroupMeDesktopClient", tempFileName + extension);
+
+            return tempFile;
+        }
+
+        /// <summary>
+        /// Initializes the temporary storage repository for use. Any existing entries in the temp
+        /// folder are deleted. If the temp folder does not exist, it will be created.
+        /// </summary>
+        public static void InitializeTempStorage()
+        {
+            if (Directory.Exists(GroupMeDesktopClientTempFolder))
+            {
+                foreach (var file in Directory.EnumerateFiles(GroupMeDesktopClientTempFolder))
+                {
+                    try
+                    {
+                        File.Delete(file);
+                    }
+                    catch (Exception)
+                    {
+                    }
+                }
+            }
+
+            Directory.CreateDirectory(GroupMeDesktopClientTempFolder);
+        }
+    }
+}

--- a/GroupMeClient/ViewModels/Controls/Attachments/FileAttachmentControlViewModel.cs
+++ b/GroupMeClient/ViewModels/Controls/Attachments/FileAttachmentControlViewModel.cs
@@ -77,9 +77,8 @@ namespace GroupMeClient.ViewModels.Controls.Attachments
             {
                 this.IsLoading = true;
                 var data = await this.FileAttachment.DownloadFileAsync(this.MessageContainer.Messages.First());
-                var extension = System.IO.Path.GetExtension(this.FileData.FileName);
-                var tempFileName = Path.GetFileNameWithoutExtension(Path.GetTempFileName());
-                var tempFile = Path.Combine(Path.GetTempPath(), "GroupMeDesktopClient", tempFileName + extension);
+
+                var tempFile = Utilities.TempFileUtils.GetTempFileName(this.FileData.FileName);
                 File.WriteAllBytes(tempFile, data);
                 System.Diagnostics.Process.Start(tempFile);
                 this.IsLoading = false;

--- a/GroupMeClient/ViewModels/MainViewModel.cs
+++ b/GroupMeClient/ViewModels/MainViewModel.cs
@@ -159,7 +159,7 @@ namespace GroupMeClient.ViewModels
         {
             Directory.CreateDirectory(this.DataRoot);
 
-            this.ClearTempFiles();
+            Utilities.TempFileUtils.InitializeTempStorage();
 
             this.SettingsManager = new Settings.SettingsManager(this.SettingsPath);
             this.SettingsManager.LoadSettings();
@@ -207,26 +207,6 @@ namespace GroupMeClient.ViewModels
 
             Native.RecoveryManager.RegisterForRecovery();
             Native.RecoveryManager.RegisterForRestart();
-        }
-
-        private void ClearTempFiles()
-        {
-            var tempFolder = Path.Combine(Path.GetTempPath(), "GroupMeDesktopClient");
-            if (Directory.Exists(tempFolder))
-            {
-                foreach (var file in Directory.EnumerateFiles(tempFolder))
-                {
-                    try
-                    {
-                        File.Delete(file);
-                    }
-                    catch (Exception)
-                    {
-                    }
-                }
-            }
-
-            Directory.CreateDirectory(tempFolder);
         }
 
         private void RegisterNotifications()


### PR DESCRIPTION
Files that are opened and hardlocked for editing by OneDrive (most frequently occurs with files opened in Microsoft Office) can be sent successfully via drag-and-drop or paste.