### PR TITLE
Feature/copy card url

### DIFF
--- a/GroupMeClient/ViewModels/Controls/Attachments/GenericLinkAttachmentControlViewModel.cs
+++ b/GroupMeClient/ViewModels/Controls/Attachments/GenericLinkAttachmentControlViewModel.cs
@@ -1,6 +1,6 @@
 ﻿using System;
-using System.Net.Http;
 using System.Threading.Tasks;
+using System.Windows;
 using System.Windows.Input;
 using System.Windows.Media;
 using GalaSoft.MvvmLight.Command;
@@ -24,6 +24,7 @@ namespace GroupMeClient.ViewModels.Controls.Attachments
             : base(url, imageDownloader)
         {
             this.Clicked = new RelayCommand(this.ClickedAction);
+            this.CopyLink = new RelayCommand(this.CopyLinkAction);
         }
 
         /// <summary>
@@ -40,6 +41,11 @@ namespace GroupMeClient.ViewModels.Controls.Attachments
         /// Gets the action to occur when the website is clicked.
         /// </summary>
         public ICommand Clicked { get; }
+
+        /// <summary>
+        /// Gets the action to occur to copy the website link URL.
+        /// </summary>
+        public ICommand CopyLink { get; }
 
         /// <summary>
         /// Gets the favicon image.
@@ -83,6 +89,11 @@ namespace GroupMeClient.ViewModels.Controls.Attachments
         private void ClickedAction()
         {
             Extensions.WebBrowserHelper.OpenUrl(this.Url);
+        }
+
+        private void CopyLinkAction()
+        {
+            Clipboard.SetText(this.Url);
         }
     }
 }

--- a/GroupMeClient/ViewModels/Controls/Attachments/ImageLinkAttachmentControlViewModel.cs
+++ b/GroupMeClient/ViewModels/Controls/Attachments/ImageLinkAttachmentControlViewModel.cs
@@ -1,4 +1,5 @@
-﻿using System.Windows.Input;
+﻿using System.Windows;
+using System.Windows.Input;
 using GalaSoft.MvvmLight.Command;
 using GroupMeClientApi;
 
@@ -22,12 +23,18 @@ namespace GroupMeClient.ViewModels.Controls.Attachments
             this.NavigateToUrl = navigateToUrl;
 
             this.Clicked = new RelayCommand(this.ClickedAction);
+            this.CopyLink = new RelayCommand(this.CopyLinkAction);
         }
 
         /// <summary>
         /// Gets the command to be performed when the image is clicked.
         /// </summary>
         public ICommand Clicked { get; }
+
+        /// <summary>
+        /// Gets the action to occur to copy the website link URL.
+        /// </summary>
+        public ICommand CopyLink { get; }
 
         private string NavigateToUrl { get; }
 
@@ -46,6 +53,12 @@ namespace GroupMeClient.ViewModels.Controls.Attachments
         {
             var navigateUrl = !string.IsNullOrEmpty(this.NavigateToUrl) ? this.NavigateToUrl : this.Url;
             Extensions.WebBrowserHelper.OpenUrl(navigateUrl);
+        }
+
+        private void CopyLinkAction()
+        {
+            var navigateUrl = !string.IsNullOrEmpty(this.NavigateToUrl) ? this.NavigateToUrl : this.Url;
+            Clipboard.SetText(navigateUrl);
         }
     }
 }

--- a/GroupMeClient/ViewModels/Controls/Attachments/LinkAttachmentBaseViewModel.cs
+++ b/GroupMeClient/ViewModels/Controls/Attachments/LinkAttachmentBaseViewModel.cs
@@ -2,7 +2,6 @@
 using System.Net;
 using System.Threading.Tasks;
 using System.Windows.Media;
-using GalaSoft.MvvmLight;
 using GroupMeClientApi;
 using Newtonsoft.Json;
 

--- a/GroupMeClient/Views/Controls/Attachments/GenericLinkAttachmentControl.xaml
+++ b/GroupMeClient/Views/Controls/Attachments/GenericLinkAttachmentControl.xaml
@@ -5,16 +5,15 @@
              xmlns:d="http://schemas.microsoft.com/expression/blend/2008"
              xmlns:behaviors="http://schemas.microsoft.com/xaml/behaviors"
              mc:Ignorable="d" 
-             d:DesignHeight="100" d:DesignWidth="400"
-             Background="White">
+             d:DesignHeight="100" d:DesignWidth="400">
 
     <behaviors:Interaction.Triggers>
-        <behaviors:EventTrigger EventName="MouseDown" >
+        <behaviors:EventTrigger EventName="MouseLeftButtonDown" >
             <behaviors:InvokeCommandAction Command="{Binding Clicked}" />
         </behaviors:EventTrigger>
     </behaviors:Interaction.Triggers>
 
-    <Grid ForceCursor="true" Cursor="Hand">
+    <Grid ForceCursor="true" Cursor="Hand" Background="White">
         <Grid.ColumnDefinitions>
             <ColumnDefinition Width="*"/>
         </Grid.ColumnDefinitions>
@@ -22,6 +21,12 @@
             <RowDefinition Height="*"/>
             <RowDefinition Height="Auto"/>
         </Grid.RowDefinitions>
+
+        <Grid.ContextMenu>
+            <ContextMenu>
+                <MenuItem Header="Copy Link" Command="{Binding CopyLink}" CommandParameter="{x:Null}" />
+            </ContextMenu>
+        </Grid.ContextMenu>
 
         <Image Grid.Row="0"
                Grid.RowSpan="2"

--- a/GroupMeClient/Views/Controls/Attachments/ImageLinkAttachmentControl.xaml
+++ b/GroupMeClient/Views/Controls/Attachments/ImageLinkAttachmentControl.xaml
@@ -6,16 +6,21 @@
              xmlns:gif="clr-namespace:XamlAnimatedGif;assembly=XamlAnimatedGif"
              xmlns:behaviors="http://schemas.microsoft.com/xaml/behaviors"
              mc:Ignorable="d" 
-             d:DesignHeight="200" d:DesignWidth="200"
-             Background="{DynamicResource ControlBackgroundBrush}">
+             d:DesignHeight="200" d:DesignWidth="200">
 
-    <Grid ForceCursor="true" Cursor="Hand">
+    <Grid ForceCursor="true" Cursor="Hand" Background="{DynamicResource ControlBackgroundBrush}">
         <behaviors:Interaction.Triggers>
-            <behaviors:EventTrigger EventName="MouseDown" >
+            <behaviors:EventTrigger EventName="MouseLeftButtonDown" >
                 <behaviors:InvokeCommandAction Command="{Binding Clicked}" />
             </behaviors:EventTrigger>
         </behaviors:Interaction.Triggers>
-        
+
+        <Grid.ContextMenu>
+            <ContextMenu>
+                <MenuItem Header="Copy Image Link" Command="{Binding CopyLink}" CommandParameter="{x:Null}" />
+            </ContextMenu>
+        </Grid.ContextMenu>
+
         <Image Grid.Row="0"
                Grid.RowSpan="2"
                MaxWidth="500" 


### PR DESCRIPTION
Added support for copying linked image URLs and web attachment URLs by right clicking the card (or image) and selecting copy from the context menu