### PR TITLE
Added support for sending replies without RMID

### DIFF
--- a/GroupMeClient/ViewModels/Controls/GroupContentsControlViewModel.cs
+++ b/GroupMeClient/ViewModels/Controls/GroupContentsControlViewModel.cs
@@ -56,7 +56,7 @@ namespace GroupMeClient.ViewModels.Controls
             {
                 ClosePopup = new RelayCommand(this.ClosePopupHandler),
                 EasyClosePopup = null,  // EasyClose makes it too easy to accidently close the send dialog.
-                PopupDialog = null
+                PopupDialog = null,
             };
 
             this.ReliabilityStateMachine = new ReliabilityStateMachine();
@@ -585,8 +585,6 @@ namespace GroupMeClient.ViewModels.Controls
 
         private async Task<Message> InjectReplyData(Message responseMessage)
         {
-            var suffix = $"\n/rmid:{this.MessageBeingRepliedTo.Message.Id}";
-
             var renderedOriginalMessage = this.RenderMessageToPngImage(this.MessageBeingRepliedTo.Message);
             var renderedImageAttachment = await GroupMeClientApi.Models.Attachments.ImageAttachment.CreateImageAttachment(renderedOriginalMessage, this.MessageContainer);
 
@@ -594,9 +592,9 @@ namespace GroupMeClient.ViewModels.Controls
             attachments.Add(renderedImageAttachment);
 
             var amendedMessage = Message.CreateMessage(
-                responseMessage.Text + suffix,
+                responseMessage.Text,
                 attachments,
-                "gmdc");
+                $"gmdc-r{this.MessageBeingRepliedTo.Message.Id}");
 
             return amendedMessage;
         }

--- a/GroupMeClient/ViewModels/Controls/MessageControlViewModel.cs
+++ b/GroupMeClient/ViewModels/Controls/MessageControlViewModel.cs
@@ -447,16 +447,28 @@ namespace GroupMeClient.ViewModels.Controls
                 }
             }
 
+            var repliedMessageId = string.Empty;
+
             // Check if this is a GroupMe Desktop Client Reply-extension message
             if (!string.IsNullOrEmpty(this.Message.Text) && Regex.IsMatch(this.Message.Text, Utilities.RegexUtils.RepliedMessageRegex))
             {
+                // Method 1, where /rmid:<message-id> is appended to the end of the message body
                 var token = Regex.Match(this.Message.Text, Utilities.RegexUtils.RepliedMessageRegex).Value;
-                var originalMessageId = token.Replace("\n/rmid:", string.Empty);
-
                 this.HiddenText = token + this.HiddenText;
+                repliedMessageId = token.Replace("\n/rmid:", string.Empty);
+            }
+            else if (this.Message.SourceGuid.StartsWith("gmdc-r"))
+            {
+                // Method 2, where gmdc-r<message-id> is included as the prefix of the message GUID
+                var parts = this.Message.SourceGuid.Split('-');
+                repliedMessageId = parts[1].Substring(1);
+            }
 
+            // Handle if this is a GroupMe Desktop Client Reply-extension message
+            if (!string.IsNullOrEmpty(repliedMessageId))
+            {
                 var container = (IMessageContainer)this.Message.Group ?? this.Message.Chat;
-                var repliedMessageAttachment = new RepliedMessageControlViewModel(originalMessageId, container, this.CacheManager, this.NestLevel);
+                var repliedMessageAttachment = new RepliedMessageControlViewModel(repliedMessageId, container, this.CacheManager, this.NestLevel);
 
                 // Replace the photo of the original message that is included for non-GMDC clients with the real message
                 if (this.AttachedItems.Count > 0)


### PR DESCRIPTION
The RMID for replies messages can be embedded in the SourceGUID, resulting in a cleaner appearance when viewed on non-GMDC clients