### PR TITLE
Feature/replied message include attachments

### DIFF
--- a/GroupMeClient/ViewModels/Controls/GroupContentsControlViewModel.cs
+++ b/GroupMeClient/ViewModels/Controls/GroupContentsControlViewModel.cs
@@ -556,9 +556,20 @@ namespace GroupMeClient.ViewModels.Controls
 
         private byte[] RenderMessageToPngImage(Message message)
         {
+            var messageDataContext = new MessageControlViewModel(message, this.CacheManager, false, true, 1);
+
+            // Copy the attachments from the version of the message that is already rendered and displayed.
+            // These attachments already have previews downloaded and ready-to-render.
+            messageDataContext.AttachedItems.Clear();
+            var displayedMessage = this.Messages.First(m => m.Id == message.Id);
+            foreach (var attachment in (displayedMessage as MessageControlViewModel).AttachedItems)
+            {
+                messageDataContext.AttachedItems.Add(attachment);
+            }
+
             var messageControl = new MessageControl()
             {
-                DataContext = new MessageControlViewModel(message, this.CacheManager, false, true, 1),
+                DataContext = displayedMessage,
                 Background = (Brush)Application.Current.FindResource("MessageTheySentBackdropBrush"),
                 Foreground = (Brush)Application.Current.FindResource("BlackBrush"),
             };

--- a/GroupMeClient/ViewModels/Controls/MessageControlViewModel.cs
+++ b/GroupMeClient/ViewModels/Controls/MessageControlViewModel.cs
@@ -58,7 +58,7 @@ namespace GroupMeClient.ViewModels.Controls
         /// <summary>
         /// Gets or sets the attached items (Tweets, Web Links, Videos, etc.), if present.
         /// </summary>
-        public ObservableCollection<ViewModelBase> AttachedItems { get; set; } = new ObservableCollection<ViewModelBase>();
+        public ObservableCollection<object> AttachedItems { get; set; } = new ObservableCollection<object>();
 
         /// <summary>
         /// Gets the command to be performed when this <see cref="Message"/> is 'Liked'.


### PR DESCRIPTION
Fixed a bug where replying to a message that included a photo or web-card would result in a blank preview bitmap being rendered for non-GMDC clients