### PR TITLE
Feature/dynamic group info update

### DIFF
--- a/GroupMeClient/ViewModels/Controls/AvatarControlViewModel.cs
+++ b/GroupMeClient/ViewModels/Controls/AvatarControlViewModel.cs
@@ -65,6 +65,11 @@ namespace GroupMeClient.ViewModels.Controls
         }
 
         /// <summary>
+        /// Gets the URL that is currently rendering in the <see cref="AvatarControlViewModel"/>.
+        /// </summary>
+        public string CurrentlyRenderedUrl { get; private set; }
+
+        /// <summary>
         /// Asychronously downloads the avatar image from GroupMe.
         /// </summary>
         /// <returns>A <see cref="Task"/> with the download status.</returns>
@@ -90,6 +95,8 @@ namespace GroupMeClient.ViewModels.Controls
             {
                 image = await this.ImageDownloader.DownloadAvatarImageAsync(this.AvatarSource.ImageOrAvatarUrl, isGroup);
             }
+
+            this.CurrentlyRenderedUrl = this.AvatarSource.ImageOrAvatarUrl;
 
             var bitmapImage = Utilities.ImageUtils.BytesToImageSource(image);
 

--- a/GroupMeClient/ViewModels/Controls/GroupContentsControlViewModel.cs
+++ b/GroupMeClient/ViewModels/Controls/GroupContentsControlViewModel.cs
@@ -285,6 +285,12 @@ namespace GroupMeClient.ViewModels.Controls
 
             // Rebind the title incase the group metadata was updated
             this.RaisePropertyChanged(nameof(this.Title));
+
+            if (this.TopBarAvatar != null && this.MessageContainer.ImageOrAvatarUrl != this.TopBarAvatar.CurrentlyRenderedUrl)
+            {
+                // Reload the avatar if the latest URL returned doesn't match what's currently rendered.
+                _ = this.TopBarAvatar.LoadAvatarAsync();
+            }
         }
 
         /// <summary>

--- a/GroupMeClient/ViewModels/Controls/GroupContentsControlViewModel.cs
+++ b/GroupMeClient/ViewModels/Controls/GroupContentsControlViewModel.cs
@@ -282,6 +282,9 @@ namespace GroupMeClient.ViewModels.Controls
         public async Task LoadNewMessages()
         {
             await this.LoadMoreAsync(null, true);
+
+            // Rebind the title incase the group metadata was updated
+            this.RaisePropertyChanged(nameof(this.Title));
         }
 
         /// <summary>

--- a/GroupMeClient/ViewModels/Controls/GroupControlViewModel.cs
+++ b/GroupMeClient/ViewModels/Controls/GroupControlViewModel.cs
@@ -60,6 +60,13 @@ namespace GroupMeClient.ViewModels.Controls
             set
             {
                 this.Set(() => this.MessageContainer, ref this.messageContainer, value);
+
+                if (this.Avatar != null && this.MessageContainer.ImageOrAvatarUrl != this.Avatar.CurrentlyRenderedUrl)
+                {
+                    // Reload the avatar if the latest URL returned doesn't match what's currently rendered.
+                    _ = this.Avatar.LoadAvatarAsync();
+                }
+
                 this.RaisePropertyChangeForAll();
             }
         }


### PR DESCRIPTION
Support for fully updating the title and avatar of chats at runtime. These changes cannot be made from within GMDC yet, but if updated by another group member on iOS/Android/Web Client/UWP, the changes will be correctly propagated and displayed without a reboot.