### PR TITLE
Feature/fix search context loading

### DIFF
--- a/GroupMeClient/Extensions/ScrollIntoViewForListbox.cs
+++ b/GroupMeClient/Extensions/ScrollIntoViewForListbox.cs
@@ -1,5 +1,6 @@
 ﻿using System;
 using System.Windows.Controls;
+using System.Windows.Input;
 using Microsoft.Xaml.Behaviors;
 
 namespace GroupMeClient.Extensions
@@ -37,11 +38,19 @@ namespace GroupMeClient.Extensions
                     listBox.Dispatcher.BeginInvoke(
                         (Action)(() =>
                         {
+                            var scrollToTopAction = ListBoxExtensions.GetScrollToTop(listBox);
+                            var scrollToBottomAction = ListBoxExtensions.GetScrollToBottom(listBox);
+                            ListBoxExtensions.SetScrollToTop(listBox, null);
+                            ListBoxExtensions.SetScrollToBottom(listBox, null);
+
                             listBox.UpdateLayout();
                             if (listBox.SelectedItem != null)
                             {
                                 listBox.ScrollIntoView(listBox.SelectedItem);
                             }
+
+                            ListBoxExtensions.SetScrollToTop(listBox, scrollToTopAction);
+                            ListBoxExtensions.SetScrollToBottom(listBox, scrollToBottomAction);
                         }));
                 }
             }

--- a/GroupMeClient/ViewModels/Controls/PaginatedMessagesControlViewModel.cs
+++ b/GroupMeClient/ViewModels/Controls/PaginatedMessagesControlViewModel.cs
@@ -32,7 +32,7 @@ namespace GroupMeClient.ViewModels.Controls
         {
             this.CacheManager = cacheManager;
             this.CurrentPage = new ObservableCollection<MessageControlViewModelBase>();
-            this.MessagesPerPage = 50;
+            this.MessagesPerPage = 25;
 
             this.GoBackCommand = new RelayCommand<ScrollViewer>(this.GoBack, this.CanGoBack);
             this.GoForwardCommand = new RelayCommand<ScrollViewer>(this.GoForward, this.CanGoForward);
@@ -189,9 +189,11 @@ namespace GroupMeClient.ViewModels.Controls
         /// <returns>A <see cref="Task"/> representing the asynchronous operation.</returns>
         public async Task EnsureVisible(Message message)
         {
-            var temp = this.Messages.ToList();
-            var index = temp.FindIndex(m => m.Id == message.Id);
+            var preceedingMessages = this.Messages
+                .Where(m => m.Id.CompareTo(message.Id) < 0)
+                .OrderBy(m => m.Id);
 
+            int index = preceedingMessages.Count();
             int pageNumber = (int)Math.Floor((double)index / this.MessagesPerPage);
             this.CurrentPageTop = pageNumber;
             this.CurrentPageBottom = pageNumber;

--- a/GroupMeClient/Views/SearchView.xaml
+++ b/GroupMeClient/Views/SearchView.xaml
@@ -132,10 +132,10 @@
             </Grid.RowDefinitions>
 
             <TextBlock Grid.Column="0"
-                           HorizontalAlignment="Left" VerticalAlignment="Center"
-                           Padding="15,0,0,0"
-                           Height="Auto" FontSize="17" FontWeight="SemiBold"
-                           Text="Search Messages" />
+                       HorizontalAlignment="Left" VerticalAlignment="Center"
+                       Padding="15,0,0,0"
+                       Height="Auto" FontSize="17" FontWeight="SemiBold"
+                       Text="Search Messages" />
 
             <Border Grid.Column="0" Grid.ColumnSpan="2" Grid.Row="0" BorderBrush="{DynamicResource DividerLineBrush}" BorderThickness="0,0,0,1" Margin="0,0,15,0"/>
         </Grid>
@@ -148,7 +148,7 @@
                      Controls:TextBoxHelper.ClearTextButton="True"
                      Controls:TextBoxHelper.UseFloatingWatermark="True"
                      FontSize="16"
-                     Text="{Binding SearchTerm, Mode=TwoWay, UpdateSourceTrigger=PropertyChanged}" >
+                     Text="{Binding SearchTerm, Mode=TwoWay, UpdateSourceTrigger=PropertyChanged, Delay=300}" >
                 <TextBox.Style>
                     <Style BasedOn="{StaticResource SearchMetroTextBox}" TargetType="{x:Type TextBox}">
                         <Style.Triggers>


### PR DESCRIPTION
- Improved the speed of loading messages in-context in the search view
- Decreased the page size of search pages to 25 messages. This will speed up loading, and shouldn't be substantially noticeable with infinite scroll. 
- Fixed an issue where the in-context message wouldn't be centered when clicked on
- Debounced search input to speed up loading