### PR TITLE
Allow custom mouse buttons for liking messages

### DIFF
--- a/GroupMeClient/Views/Controls/MessageControl.xaml
+++ b/GroupMeClient/Views/Controls/MessageControl.xaml
@@ -172,8 +172,9 @@
                         Content="{Binding LikeCount}" />
 
                     <behaviors:Interaction.Triggers>
-                        <behaviors:EventTrigger EventName="MouseLeftButtonDown" >
-                            <behaviors:InvokeCommandAction Command="{Binding LikeAction}" />
+                        <behaviors:EventTrigger EventName="MouseDown" >
+                            <behaviors:InvokeCommandAction Command="{Binding LikeAction}"
+                                                           PassEventArgsToCommand="True"/>
                         </behaviors:EventTrigger>
                     </behaviors:Interaction.Triggers>
 


### PR DESCRIPTION
Restored the previous behavior of GMDC 26 which allowed for liking messages with any mouse button other than right-click.

This includes custom programmable buttons, side-click buttons, and the center button, if available. Right click is reserved for starring.