### PR TITLE
Added support for changing a group name, topic, avatar, and mute status

### DIFF
--- a/GroupMeClient/App.xaml
+++ b/GroupMeClient/App.xaml
@@ -23,13 +23,14 @@
                 <ResourceDictionary Source="pack://application:,,,/MahApps.Metro;component/Styles/Fonts.xaml" />
                 <ResourceDictionary Source="pack://application:,,,/MahApps.Metro;component/Styles/Colors.xaml" />
                 <ResourceDictionary Source="pack://application:,,,/MahApps.Metro;component/Styles/FlatButton.xaml" />
-
+                
                 <ResourceDictionary Source="pack://application:,,,/MahApps.Metro;component/Styles/Accents/Blue.xaml" />
 
                 <ResourceDictionary Source="pack://application:,,,/MahApps.Metro;component/Styles/Accents/BaseLight.xaml" />
                 <ResourceDictionary Source="pack://application:,,,/GroupMeLight.xaml" />
             </ResourceDictionary.MergedDictionaries>
             <Style TargetType="{x:Type Controls:WindowButtonCommands}" BasedOn="{StaticResource MahApps.Metro.Styles.WindowButtonCommands.Win10}" />
+            <Style TargetType="{x:Type Controls:ToggleSwitch}" BasedOn="{StaticResource MahApps.Metro.Styles.ToggleSwitch.Win10}" />
 
             <!--
             We define the data templates here so we can apply them across the

--- a/GroupMeClient/GroupMeClient.csproj
+++ b/GroupMeClient/GroupMeClient.csproj
@@ -483,7 +483,7 @@
       <PrivateAssets>all</PrivateAssets>
     </PackageReference>
     <PackageReference Include="GroupMeClientApi">
-      <Version>1.0.5</Version>
+      <Version>1.0.6</Version>
     </PackageReference>
     <PackageReference Include="GroupMeClientPlugin">
       <Version>2.0.1</Version>
@@ -543,7 +543,6 @@
       <Version>1.2.2</Version>
     </PackageReference>
   </ItemGroup>
-  <ItemGroup />
   <Import Project="$(MSBuildToolsPath)\Microsoft.CSharp.targets" />
   <ItemGroup>
     <NuGetCommandLine Include="..\packages\NuGet.CommandLine.*\tools\nuget.exe">

--- a/GroupMeClient/Plugins/Views/GroupInfoControl.xaml
+++ b/GroupMeClient/Plugins/Views/GroupInfoControl.xaml
@@ -38,6 +38,7 @@
 
     <behaviors:Interaction.Triggers>
         <extensions:HandlingEventTrigger EventName="MouseLeftButtonDown" >
+            <!--Empty trigger to capture and handle mouse-events so they don't bubble up to Popup.xaml and cause the dialog to close-->
         </extensions:HandlingEventTrigger>
     </behaviors:Interaction.Triggers>
 
@@ -237,13 +238,165 @@
                        
                         </StackPanel>
                     </Grid>
-                  
-                    
+                </Grid>
+            </TabItem>
+
+            <TabItem Header="Update Group" Style="{StaticResource tabStyle}">
+                <Grid>
+                    <Grid.ColumnDefinitions>
+                        <ColumnDefinition Width="1.5*"/>
+                        <ColumnDefinition Width="*"/>
+                    </Grid.ColumnDefinitions>
+                    <Grid.RowDefinitions>
+                        <RowDefinition Height="*"/>
+                    </Grid.RowDefinitions>
+
+
+                    <StackPanel Orientation="Vertical"
+                                Grid.Column="0"
+                                Margin="0,7,0,0">
+
+                        <!--Update Group Name-->
+                        <Grid>
+                            <Grid.ColumnDefinitions>
+                                <ColumnDefinition Width="Auto" />
+                                <ColumnDefinition Width="*" />
+                                <ColumnDefinition Width="Auto" />
+                            </Grid.ColumnDefinitions>
+                           
+                            <TextBlock Text="Group Name: "
+                                       Foreground="White"
+                                       FontSize="14"
+                                       VerticalAlignment="Center"/>
+
+                            <TextBlock Text="{Binding GroupName}"
+                                       Visibility="{Binding IsEditingGroupName, Converter={StaticResource inverseBooleanToVisibilityConverter}}"
+                                       VerticalAlignment="Center"
+                                       Padding="6,4,2,4"
+                                       Grid.Column="1"
+                                       Foreground="White"
+                                       FontSize="14"/>
+
+                            <TextBox Text="{Binding GroupName, Mode=TwoWay}"
+                                     Visibility="{Binding IsEditingGroupName, Converter={StaticResource boolToVisibilityConverter}}"
+                                     Grid.Column="1"
+                                     CaretBrush="White"
+                                     Foreground="White"
+                                     Background="Black"
+                                     FontSize="14"/>
+
+                            <Button Grid.Column="2"
+                                    Command="{Binding EditGroupNameCommand}"
+                                    Foreground="White"
+                                    Style="{StaticResource {x:Static ToolBar.ButtonStyleKey}}"
+                                    Visibility="{Binding IsEditingGroupName, Converter={StaticResource inverseBooleanToVisibilityConverter}}">
+                                <iconPacks:PackIconEntypo Kind="Edit" Foreground="White"/>
+                            </Button>
+
+                            <Button Grid.Column="2"
+                                    Command="{Binding EditGroupNameCommand}"
+                                    Foreground="White"
+                                    Style="{StaticResource {x:Static ToolBar.ButtonStyleKey}}"
+                                    Visibility="{Binding IsEditingGroupName, Converter={StaticResource boolToVisibilityConverter}}">
+                                <iconPacks:PackIconMaterial Kind="Check" />
+                            </Button>
+                        </Grid>
+
+                        <!--Update Group Description-->
+                        <Grid Margin="0,10,0,0">
+                            <Grid.ColumnDefinitions>
+                                <ColumnDefinition Width="Auto" />
+                                <ColumnDefinition Width="*" />
+                                <ColumnDefinition Width="Auto" />
+                            </Grid.ColumnDefinitions>
+
+                            <TextBlock Text="Description: "
+                                       Foreground="White"
+                                       FontSize="14"
+                                       Margin="0,2,0,0"
+                                       VerticalAlignment="Top"/>
+
+                            <TextBlock Text="{Binding GroupDescription}"
+                                       Visibility="{Binding IsEditingGroupDescription, Converter={StaticResource inverseBooleanToVisibilityConverter}}"
+                                       VerticalAlignment="Center"
+                                       Padding="6,4,2,4"
+                                       Grid.Column="1"
+                                       Foreground="White"
+                                       FontSize="14"/>
+
+                            <TextBox Text="{Binding GroupDescription, Mode=TwoWay}"
+                                     Visibility="{Binding IsEditingGroupDescription, Converter={StaticResource boolToVisibilityConverter}}"
+                                     Grid.Column="1"
+                                     CaretBrush="White"
+                                     Foreground="White"
+                                     Background="Black"
+                                     AcceptsReturn="True"
+                                     FontSize="14"/>
+
+                            <Button Grid.Column="2"
+                                    Command="{Binding EditGroupDescriptionCommand}"
+                                    Foreground="White"
+                                    VerticalAlignment="Top"
+                                    Style="{StaticResource {x:Static ToolBar.ButtonStyleKey}}"
+                                    Visibility="{Binding IsEditingGroupDescription, Converter={StaticResource inverseBooleanToVisibilityConverter}}">
+                                <iconPacks:PackIconEntypo Kind="Edit" Foreground="White"/>
+                            </Button>
+
+                            <Button Grid.Column="2"
+                                    Command="{Binding EditGroupDescriptionCommand}"
+                                    Foreground="White"
+                                    Style="{StaticResource {x:Static ToolBar.ButtonStyleKey}}"
+                                    Visibility="{Binding IsEditingGroupDescription, Converter={StaticResource boolToVisibilityConverter}}">
+                                <iconPacks:PackIconMaterial Kind="Check" />
+                            </Button>
+                        </Grid>
+
+                    </StackPanel>
+
+                    <Grid Grid.Row="0"
+                          x:Name="GroupAvatarEditor" 
+                          Background="Transparent"
+                          Grid.Column="1"
+                          Grid.RowSpan="2">
+
+                        <Grid.RowDefinitions>
+                            <RowDefinition Height="*"/>
+                            <RowDefinition Height="Auto" />
+                        </Grid.RowDefinitions>
+                        
+                        <ContentControl Width="150"
+                                        Height="150"
+                                        HorizontalAlignment="Center"
+                                        VerticalAlignment="Top"
+                                        Content="{Binding GroupAvatar}">
+
+                            <behaviors:Interaction.Triggers>
+                                <behaviors:EventTrigger EventName="MouseDown" >
+                                    <behaviors:InvokeCommandAction Command="{Binding ShowImageCommand}"
+                                                                   CommandParameter="{Binding RelativeSource={RelativeSource FindAncestor, 
+                                                                                      AncestorType={x:Type ContentControl}}, Path=Content}" />
+                                </behaviors:EventTrigger>
+                            </behaviors:Interaction.Triggers>
+                        </ContentControl>
+
+                        <StackPanel HorizontalAlignment="Center"
+                                    VerticalAlignment="Center">
+                            <Button Width="120"
+                                    Opacity="0.8"
+                                    FontSize="12"
+                                    Visibility="{Binding Path=IsMouseOver, ElementName=GroupAvatarEditor, Converter={StaticResource boolToVisibilityConverter}}"
+                                    Command="{Binding ChangeGroupAvatarCommand}"
+                                    Content="Change Avatar" />
+                        </StackPanel>
+
+                        <Controls:ToggleSwitch Content="Mute Group"
+                                               Grid.Row="1"
+                                               IsChecked="{Binding IsMuted}"
+                                               HorizontalAlignment="Center"/>
+                    </Grid>
                 </Grid>
             </TabItem>
         </TabControl>
     </Grid>
-    
-   
 </UserControl>
     


### PR DESCRIPTION
Adds support for:
- Changing the name of a group
- Changing the group description/topic
- Changing the group avatar
- Muting a group

This closes #128 