### PR TITLE
Downgraded GitInfo NuGet package to resolve numbering issues

### DIFF
--- a/GroupMeClient.Core/GroupMeClient.Core.csproj
+++ b/GroupMeClient.Core/GroupMeClient.Core.csproj
@@ -26,7 +26,7 @@
   
   <ItemGroup>
     <PackageReference Include="DynamicData" Version="6.16.3" />
-    <PackageReference Include="GitInfo" Version="2.0.31">
+    <PackageReference Include="GitInfo" Version="2.0.26">
       <PrivateAssets>all</PrivateAssets>
       <IncludeAssets>runtime; build; native; contentfiles; analyzers; buildtransitive</IncludeAssets>
     </PackageReference>


### PR DESCRIPTION
In new versions of GitInfo (2.0.31 at the time of testing), the patch version is always blank. This results in an incorrect application version number for both GroupMeCore and GMDC/Wpf. Issue solved by downgrading to the prior package version.