### PR TITLE
Feature/fix windows7

### DIFF
--- a/GroupMeClient.Core/Startup.cs
+++ b/GroupMeClient.Core/Startup.cs
@@ -6,6 +6,7 @@ using GroupMeClient.Core.Settings;
 using GroupMeClient.Core.Tasks;
 using GroupMeClient.Core.ViewModels;
 using GroupMeClientPlugin.GroupChat;
+using System.Net;
 
 namespace GroupMeClient.Core
 {
@@ -27,6 +28,8 @@ namespace GroupMeClient.Core
             SimpleIoc.Default.Register(() => new SettingsManager(startupParameters.SettingsFilePath));
             SimpleIoc.Default.Register(() => new PluginInstaller(startupParameters.PluginPath));
             SimpleIoc.Default.Register<PluginHost>();
+
+            AdditionalStartupConfig();
         }
 
         /// <summary>
@@ -43,6 +46,12 @@ namespace GroupMeClient.Core
             SimpleIoc.Default.Register<IPluginUIIntegration>(
                 () => SimpleIoc.Default.GetInstance<SearchViewModel>(),
                 createInstanceImmediately: false);
+        }
+
+        private static void AdditionalStartupConfig()
+        {
+            // Windows 7 and prior will not have TLS1.2 enabled by default in all cases.
+            ServicePointManager.SecurityProtocol |= SecurityProtocolType.Tls12;
         }
 
         /// <summary>

--- a/GroupMeClient.WpfUI/GroupMeClient.WpfUI.csproj
+++ b/GroupMeClient.WpfUI/GroupMeClient.WpfUI.csproj
@@ -481,7 +481,7 @@
       <Version>1.1.19</Version>
     </PackageReference>
     <PackageReference Include="Notification.WPF">
-      <Version>1.0.2.1</Version>
+      <Version>1.0.1.11</Version>
     </PackageReference>
     <PackageReference Include="NuGet.CommandLine">
       <Version>5.6.0</Version>


### PR DESCRIPTION
Resolved issues on Windows 7:
- Plugins would not install and the application would not update due to lacking TLS 1.2 support by default
- Regression in external notification framework caused a crash with popup system notifications 