### PR TITLE
Applied .NET Spell Check Patch

### DIFF
--- a/GroupMeClient.WpfUI/App.config
+++ b/GroupMeClient.WpfUI/App.config
@@ -1,5 +1,9 @@
 <?xml version="1.0" encoding="utf-8"?>
 <configuration>
+    <runtime>
+      <AppContextSwitchOverrides value="Switch.System.Windows.Controls.DoNotAugmentWordBreakingUsingSpeller=true"/>
+    </runtime>
+  
     <startup> 
         <supportedRuntime version="v4.0" sku=".NETFramework,Version=v4.7.2"/>
     </startup>


### PR DESCRIPTION
Applied recommended patch from dotnet/wpf#3350 (comment) to help mitigate the performance impact to spell checking and message composition for WIndows 10 1903+ on .NET Framework updates post Sept. 2020