### PR TITLE
Fixed the client label for messages sent on GM iOS using the Share menu

### DIFF
--- a/GroupMeClient.Core/ViewModels/Controls/MessageControlViewModel.cs
+++ b/GroupMeClient.Core/ViewModels/Controls/MessageControlViewModel.cs
@@ -265,6 +265,10 @@ namespace GroupMeClient.Core.ViewModels.Controls
                 {
                     return "iOS";
                 }
+                else if (this.message.SourceGuid.StartsWith("iosshareext"))
+                {
+                    return "iOS (Share)";
+                }
                 else if (!this.message.SourceGuid.Contains("-"))
                 {
                     return "Web Client";


### PR DESCRIPTION
Previously, messages shared through the iOS Share Menu showed as being sent from GroupMe UWP, instead of iOS.