### PR TITLE
Feature/image size prelayout

### DIFF
--- a/GroupMeClient.Core/Services/IImageService.cs
+++ b/GroupMeClient.Core/Services/IImageService.cs
@@ -1,0 +1,16 @@
+﻿namespace GroupMeClient.Core.Services
+{
+    /// <summary>
+    /// <see cref="IImageService"/> provides a platform agnostic service for image generation.
+    /// </summary>
+    public interface IImageService
+    {
+        /// <summary>
+        /// Creates a transparent placeholder PNG image of a specific size.
+        /// </summary>
+        /// <param name="width">The width of the image to generate.</param>
+        /// <param name="height">The height of the image to generate.</param>
+        /// <returns>A byte array containing the a transparent image encoded in PNG format.</returns>
+        byte[] CreateTransparentPng(int width, int height);
+    }
+}

--- a/GroupMeClient.Core/Services/IMessageBoxService.cs
+++ b/GroupMeClient.Core/Services/IMessageBoxService.cs
@@ -1,6 +1,4 @@
 ﻿using System;
-using System.Collections.Generic;
-using System.Text;
 
 namespace GroupMeClient.Core.Services
 {
@@ -9,6 +7,10 @@ namespace GroupMeClient.Core.Services
     /// </summary>
     public interface IMessageBoxService
     {
-        void ShowMessageBox(MessageBoxParams paramters);
+        /// <summary>
+        /// Displays a message box.
+        /// </summary>
+        /// <param name="parameters">The parameters for the message box to display.</param>
+        void ShowMessageBox(MessageBoxParams parameters);
     }
 }

--- a/GroupMeClient.Core/ViewModels/Controls/Attachments/GroupMeImageAttachmentControlViewModel.cs
+++ b/GroupMeClient.Core/ViewModels/Controls/Attachments/GroupMeImageAttachmentControlViewModel.cs
@@ -1,9 +1,12 @@
 ﻿using System;
+using System.IO;
 using System.Threading.Tasks;
 using System.Windows.Input;
 using GalaSoft.MvvmLight;
 using GalaSoft.MvvmLight.Command;
+using GalaSoft.MvvmLight.Ioc;
 using GalaSoft.MvvmLight.Messaging;
+using GroupMeClient.Core.Services;
 using GroupMeClientApi;
 using GroupMeClientApi.Models.Attachments;
 
@@ -31,6 +34,7 @@ namespace GroupMeClient.Core.ViewModels.Controls.Attachments
             this.PreviewMode = previewMode;
 
             this.IsLoading = true;
+            this.GenerateSizedPlaceholder();
             Task.Run(this.LoadImageAttachment);
         }
 
@@ -120,6 +124,7 @@ namespace GroupMeClient.Core.ViewModels.Controls.Attachments
                 return;
             }
 
+            this.ImageAttachmentStream?.Dispose();
             this.ImageAttachmentStream = new System.IO.MemoryStream(image);
             this.IsLoading = false;
         }
@@ -130,6 +135,38 @@ namespace GroupMeClient.Core.ViewModels.Controls.Attachments
 
             var request = new Messaging.DialogRequestMessage(vm);
             Messenger.Default.Send(request);
+        }
+
+        private void GenerateSizedPlaceholder()
+        {
+            // Assign a dummy image of the same size to allow for immediate layout
+            // operations to be completed accurately before the full image loads
+            var dimensions = this.GetScaledImageDimensions();
+            var imageService = SimpleIoc.Default.GetInstance<IImageService>();
+            var bytes = imageService.CreateTransparentPng(dimensions.Item1, dimensions.Item2);
+            this.ImageAttachmentStream = new MemoryStream(bytes);
+        }
+
+        private Tuple<int, int> GetScaledImageDimensions()
+        {
+            if (this.PreviewMode == GroupMeImageDisplayMode.Preview)
+            {
+                return new Tuple<int, int>(200, 200);
+            }
+
+            var choppedUrl = new Uri(this.ImageAttachment.Url).AbsolutePath.Substring(1).Split('.')[0];
+            var dimensionsStr = choppedUrl.Split('x');
+
+            int.TryParse(dimensionsStr[0], out var width);
+            int.TryParse(dimensionsStr[1], out var height);
+
+            // GroupMe in large mode limits images to 960px in the largest dimensions. Small mode is not documented for the limits.
+            const int MaxImageDim = 960;
+
+            var largestSide = Math.Max(width, height);
+            var scale = Math.Min(1.0, (double)MaxImageDim / largestSide);
+
+            return new Tuple<int, int>((int)(width * scale), (int)(height * scale));
         }
     }
 }

--- a/GroupMeClient.WpfUI/GroupMeClient.WpfUI.csproj
+++ b/GroupMeClient.WpfUI/GroupMeClient.WpfUI.csproj
@@ -87,6 +87,7 @@
     <Compile Include="Plugins\PluginManager.cs" />
     <Compile Include="Services\WpfClipboardService.cs" />
     <Compile Include="Services\WpfDispatcherService.cs" />
+    <Compile Include="Services\WpfImageService.cs" />
     <Compile Include="Services\WpfMessageBoxService.cs" />
     <Compile Include="Services\WpfMessageRenderer.cs" />
     <Compile Include="Converters\IsGreaterThanConverter.cs" />

--- a/GroupMeClient.WpfUI/Services/WpfClipboardService.cs
+++ b/GroupMeClient.WpfUI/Services/WpfClipboardService.cs
@@ -5,6 +5,9 @@ using GroupMeClient.Core.Services;
 
 namespace GroupMeClient.WpfUI.Services
 {
+    /// <summary>
+    /// <see cref="WpfClipboardService"/> implements clipboard services on the Wpf/Windows platform.
+    /// </summary>
     public class WpfClipboardService : IClipboardService
     {
         /// <inheritdoc/>

--- a/GroupMeClient.WpfUI/Services/WpfImageService.cs
+++ b/GroupMeClient.WpfUI/Services/WpfImageService.cs
@@ -1,0 +1,32 @@
+﻿using System;
+using System.Collections.Generic;
+using System.Windows.Media;
+using System.Windows.Media.Imaging;
+using GroupMeClient.Core.Services;
+
+namespace GroupMeClient.WpfUI.Services
+{
+    /// <summary>
+    /// <see cref="WpfImageService"/> provides image generators using Wpf Imaging APIs.
+    /// </summary>
+    public class WpfImageService : IImageService
+    {
+        /// <inheritdoc/>
+        public byte[] CreateTransparentPng(int width, int height)
+        {
+            var tinyImg = BitmapSource.Create(
+                pixelWidth: 1,
+                pixelHeight: 1,
+                96,
+                96,
+                PixelFormats.Bgr24,
+                new BitmapPalette(new List<Color> { Colors.Transparent }),
+                new byte[] { 0, 0, 0 },
+                3);
+
+            var scaledImg = new TransformedBitmap(tinyImg, new ScaleTransform(width, height));
+
+            return Utilities.ImageUtils.BitmapSourceToBytes(scaledImg);
+        }
+    }
+}

--- a/GroupMeClient.WpfUI/Startup.cs
+++ b/GroupMeClient.WpfUI/Startup.cs
@@ -20,6 +20,7 @@ namespace GroupMeClient.WpfUI
             SimpleIoc.Default.Register<Core.Services.IMessageRendererService, Services.WpfMessageRenderer>();
             SimpleIoc.Default.Register<Core.Services.IUserInterfaceDispatchService, Services.WpfDispatcherService>();
             SimpleIoc.Default.Register<Core.Services.IRestoreService, Services.WpfRestoreService>();
+            SimpleIoc.Default.Register<Core.Services.IImageService, Services.WpfImageService>();
 
             // Setup Themeing
             SimpleIoc.Default.Register<Core.Services.IThemeService, Services.WpfThemeService>();


### PR DESCRIPTION
Placeholder images are used to allow for precomputed layouts while attachments are downloading. This improves scrolling performance and reduces jumping/jitter on load.