### PR TITLE
Resolved UNSECURE commands in build action

### DIFF
--- a/.github/workflows/CreateRelease.yml
+++ b/.github/workflows/CreateRelease.yml
@@ -8,19 +8,15 @@ on:
 jobs:
   build:
     runs-on: windows-latest
-    env:
-      ACTIONS_ALLOW_UNSECURE_COMMANDS: true
 
     steps:
     - uses: actions/checkout@v2
-    - name: Setup Nuget.exe
-      uses: warrenbuckley/Setup-Nuget@v1
-    - name: Restore packages
-      run: nuget restore GroupMeClient.sln
-    - name: Setup MSBuild.exe
-      uses: warrenbuckley/Setup-MSBuild@v1
+    - name: Setup MSBuild
+      uses: microsoft/setup-msbuild@v1.0.2
+    - name: Restore with MSBuild
+      run: msbuild GroupMeClient.WpfUI -t:restore
     - name: Build with MSBuild
-      run: msbuild  GroupMeClient.WpfUI -p:Configuration=Release
+      run: msbuild GroupMeClient.WpfUI -p:Configuration=Release -t:restore
     - name: Get the version
       id: get_version
       run: echo ::set-output name=VERSION::${GITHUB_REF/refs\/tags\//}


### PR DESCRIPTION
Updated Release workflow to no longer require UNSECURE commands and to use new Microsoft actions