### PR TITLE
Feature/mini chat default location

### DIFF
--- a/GroupMeClient.Core/Services/WindowParams.cs
+++ b/GroupMeClient.Core/Services/WindowParams.cs
@@ -42,6 +42,11 @@ namespace GroupMeClient.Core.Services
             /// The default location, as determined by the system.
             /// </summary>
             Default,
+
+            /// <summary>
+            /// A manually set X, Y position.
+            /// </summary>
+            Manual,
         }
 
         /// <summary>
@@ -85,5 +90,17 @@ namespace GroupMeClient.Core.Services
         /// Gets or sets the default window starting location.
         /// </summary>
         public Location StartingLocation { get; set; } = Location.Default;
+
+        /// <summary>
+        /// Gets or sets the starting X position of the window if <see cref="StartingLocation"/>
+        /// is set to <see cref="Location.Manual"/>.
+        /// </summary>
+        public double StartingX { get; set; }
+
+        /// <summary>
+        /// Gets or sets the starting Y position of the window if <see cref="StartingLocation"/>
+        /// is set to <see cref="Location.Manual"/>.
+        /// </summary>
+        public double StartingY { get; set; }
     }
 }

--- a/GroupMeClient.Core/Services/WindowParams.cs
+++ b/GroupMeClient.Core/Services/WindowParams.cs
@@ -9,6 +9,42 @@ namespace GroupMeClient.Core.Services
     public class WindowParams
     {
         /// <summary>
+        /// Placement locations for an on-screen window.
+        /// </summary>
+        public enum Location
+        {
+            /// <summary>
+            /// Center of the screen.
+            /// </summary>
+            CenterScreen,
+
+            /// <summary>
+            /// The bottom left corner of the screen.
+            /// </summary>
+            BottomLeft,
+
+            /// <summary>
+            /// The bottom right corner of the screen.
+            /// </summary>
+            BottomRight,
+
+            /// <summary>
+            /// The top left corner of the screen.
+            /// </summary>
+            TopLeft,
+
+            /// <summary>
+            /// The top right corner of the screen.
+            /// </summary>
+            TopRight,
+
+            /// <summary>
+            /// The default location, as determined by the system.
+            /// </summary>
+            Default,
+        }
+
+        /// <summary>
         /// Gets or sets the contents to display in the window.
         /// </summary>
         public ViewModelBase Content { get; set; }
@@ -44,5 +80,10 @@ namespace GroupMeClient.Core.Services
         /// Gets or sets an optional tag value.
         /// </summary>
         public string Tag { get; set; }
+
+        /// <summary>
+        /// Gets or sets the default window starting location.
+        /// </summary>
+        public Location StartingLocation { get; set; } = Location.Default;
     }
 }

--- a/GroupMeClient.Core/Settings/UISettings.cs
+++ b/GroupMeClient.Core/Settings/UISettings.cs
@@ -57,6 +57,23 @@ namespace GroupMeClient.Core.Settings
         public bool EnableNonNativeNotifications { get; set; } = true;
 
         /// <summary>
+        /// Gets or sets the starting window placement for new MiniChat instances.
+        /// </summary>
+        [JsonConverter(typeof(StringEnumConverter))]
+        public WindowParams.Location MiniChatOpenLocation { get; set; } = WindowParams.Location.BottomRight;
+
+        /// <summary>
+        /// Gets or sets the starting window position for MiniChats when <see cref="MiniChatOpenLocation"/>
+        /// is set to <see cref="WindowParams.Location.Manual"/>.
+        /// </summary>
+        public double MiniChatManualX { get; set; } = 0;
+
+        /// <summary>
+        /// Gets or sets the starting window position for MiniChats when <see cref="MiniChatOpenLocation"/>
+        /// is set to <see cref="WindowParams.Location.Manual"/>.
+        public double MiniChatManualY { get; set; } = 0;
+
+        /// <summary>
         /// Gets or sets the user selected theme that should be applied to the entire application UI.
         /// </summary>
         [JsonConverter(typeof(StringEnumConverter))]

--- a/GroupMeClient.Core/ViewModels/Controls/GroupContentsControlViewModel.cs
+++ b/GroupMeClient.Core/ViewModels/Controls/GroupContentsControlViewModel.cs
@@ -877,6 +877,7 @@ namespace GroupMeClient.Core.ViewModels.Controls
                 Width = 350,
                 Height = 550,
                 TopMost = true,
+                StartingLocation = WindowParams.Location.BottomRight,
                 Tag = this.Id,
                 CloseCallback = () => this.CloseMiniChat?.Execute(this),
             });

--- a/GroupMeClient.Core/ViewModels/Controls/GroupContentsControlViewModel.cs
+++ b/GroupMeClient.Core/ViewModels/Controls/GroupContentsControlViewModel.cs
@@ -877,7 +877,9 @@ namespace GroupMeClient.Core.ViewModels.Controls
                 Width = 350,
                 Height = 550,
                 TopMost = true,
-                StartingLocation = WindowParams.Location.BottomRight,
+                StartingLocation = this.Settings.UISettings.MiniChatOpenLocation,
+                StartingX = this.Settings.UISettings.MiniChatManualX,
+                StartingY = this.Settings.UISettings.MiniChatManualY,
                 Tag = this.Id,
                 CloseCallback = () => this.CloseMiniChat?.Execute(this),
             });

--- a/GroupMeClient.WpfUI/Services/WpfWindowService.cs
+++ b/GroupMeClient.WpfUI/Services/WpfWindowService.cs
@@ -62,6 +62,12 @@ namespace GroupMeClient.WpfUI.Services
                     window.WindowStartupLocation = WindowStartupLocation.Manual;
                     break;
 
+                case WindowParams.Location.Manual:
+                    window.WindowStartupLocation = WindowStartupLocation.Manual;
+                    window.Left = windowParams.StartingX;
+                    window.Top = windowParams.StartingY;
+                    break;
+
                 case WindowParams.Location.CenterScreen:
                     window.WindowStartupLocation = WindowStartupLocation.CenterScreen;
                     break;

--- a/GroupMeClient.WpfUI/Services/WpfWindowService.cs
+++ b/GroupMeClient.WpfUI/Services/WpfWindowService.cs
@@ -1,5 +1,6 @@
 ﻿using System;
 using System.Windows;
+using System.Windows.Interop;
 using GroupMeClient.Core.Services;
 using GroupMeClient.WpfUI.ViewModels;
 using GroupMeClient.WpfUI.Views;
@@ -50,6 +51,44 @@ namespace GroupMeClient.WpfUI.Services
             if (windowParams.Height > 0)
             {
                 window.Height = windowParams.Height;
+            }
+
+            var screen = SystemParameters.WorkArea;
+            var windowOffset = 7;
+
+            switch (windowParams.StartingLocation)
+            {
+                case WindowParams.Location.Default:
+                    window.WindowStartupLocation = WindowStartupLocation.Manual;
+                    break;
+
+                case WindowParams.Location.CenterScreen:
+                    window.WindowStartupLocation = WindowStartupLocation.CenterScreen;
+                    break;
+
+                case WindowParams.Location.BottomRight:
+                    window.WindowStartupLocation = WindowStartupLocation.Manual;
+                    window.Left = screen.Right - window.Width + windowOffset;
+                    window.Top = screen.Bottom - window.Height + windowOffset;
+                    break;
+
+                case WindowParams.Location.BottomLeft:
+                    window.WindowStartupLocation = WindowStartupLocation.Manual;
+                    window.Left = screen.Left;
+                    window.Top = screen.Bottom - window.Height + windowOffset;
+                    break;
+
+                case WindowParams.Location.TopLeft:
+                    window.WindowStartupLocation = WindowStartupLocation.Manual;
+                    window.Left = screen.Left;
+                    window.Top = screen.Top;
+                    break;
+
+                case WindowParams.Location.TopRight:
+                    window.WindowStartupLocation = WindowStartupLocation.Manual;
+                    window.Left = screen.Right - window.Width + windowOffset;
+                    window.Top = screen.Top;
+                    break;
             }
 
             window.Closing += (s, e) => windowParams.CloseCallback?.Invoke();


### PR DESCRIPTION
Adds support for setting the location of the MiniChat window.
By default, MiniChats will open in the bottom right corner of the screen. Options in the JSON config allow for custom locations.