### PR TITLE
Feature/NuGet Updates 3/23/21

### DIFF
--- a/GroupMeClient.Core/GroupMeClient.Core.csproj
+++ b/GroupMeClient.Core/GroupMeClient.Core.csproj
@@ -32,11 +32,11 @@
     </PackageReference>
     <PackageReference Include="GroupMeClientApi" Version="1.1.0" />
     <PackageReference Include="GroupMeClientPlugin" Version="2.0.2" />
-    <PackageReference Include="Microsoft.EntityFrameworkCore.Sqlite" Version="3.1.9">
+    <PackageReference Include="Microsoft.EntityFrameworkCore.Sqlite" Version="3.1.13">
       <PrivateAssets>none</PrivateAssets>
       <ExcludeAssets>none</ExcludeAssets>
     </PackageReference>
-    <PackageReference Include="Microsoft.EntityFrameworkCore.Tools" Version="3.1.9">
+    <PackageReference Include="Microsoft.EntityFrameworkCore.Tools" Version="3.1.13">
       <PrivateAssets>all</PrivateAssets>
       <IncludeAssets>runtime; build; native; contentfiles; analyzers; buildtransitive</IncludeAssets>
     </PackageReference>

--- a/GroupMeClient.Core/GroupMeClient.Core.csproj
+++ b/GroupMeClient.Core/GroupMeClient.Core.csproj
@@ -41,12 +41,12 @@
       <IncludeAssets>runtime; build; native; contentfiles; analyzers; buildtransitive</IncludeAssets>
     </PackageReference>
     <PackageReference Include="MvvmLightLibsStd10" Version="5.4.1.1" />
-    <PackageReference Include="NuGet.CommandLine" Version="5.8.0">
+    <PackageReference Include="NuGet.CommandLine" Version="5.8.1">
       <PrivateAssets>all</PrivateAssets>
       <IncludeAssets>runtime; build; native; contentfiles; analyzers; buildtransitive</IncludeAssets>
     </PackageReference>
-    <PackageReference Include="Octokit" Version="0.48.0" />
-    <PackageReference Include="ReactiveUI" Version="13.0.27" />
+    <PackageReference Include="Octokit" Version="0.50.0" />
+    <PackageReference Include="ReactiveUI" Version="13.2.2" />
     <PackageReference Include="SQLitePCLRaw.bundle_e_sqlite3" Version="2.0.4" />
     <PackageReference Include="StyleCop.Analyzers" Version="1.1.118">
       <PrivateAssets>all</PrivateAssets>

--- a/GroupMeClient.Core/GroupMeClient.Core.csproj
+++ b/GroupMeClient.Core/GroupMeClient.Core.csproj
@@ -47,6 +47,7 @@
     </PackageReference>
     <PackageReference Include="Octokit" Version="0.48.0" />
     <PackageReference Include="ReactiveUI" Version="13.0.27" />
+    <PackageReference Include="SQLitePCLRaw.bundle_e_sqlite3" Version="2.0.4" />
     <PackageReference Include="StyleCop.Analyzers" Version="1.1.118">
       <PrivateAssets>all</PrivateAssets>
       <IncludeAssets>runtime; build; native; contentfiles; analyzers; buildtransitive</IncludeAssets>

--- a/GroupMeClient.WpfUI/GroupMeClient.WpfUI.csproj
+++ b/GroupMeClient.WpfUI/GroupMeClient.WpfUI.csproj
@@ -497,7 +497,7 @@
       <Version>1.1.31</Version>
     </PackageReference>
     <PackageReference Include="Notification.WPF">
-      <Version>1.0.1.11</Version>
+      <Version>2.0.0.8</Version>
     </PackageReference>
     <PackageReference Include="NuGet.CommandLine">
       <Version>5.8.1</Version>

--- a/GroupMeClient.WpfUI/GroupMeClient.WpfUI.csproj
+++ b/GroupMeClient.WpfUI/GroupMeClient.WpfUI.csproj
@@ -468,7 +468,7 @@
   </ItemGroup>
   <ItemGroup>
     <PackageReference Include="MahApps.Metro">
-      <Version>2.4.3</Version>
+      <Version>2.4.4</Version>
     </PackageReference>
     <PackageReference Include="MahApps.Metro.IconPacks.Entypo">
       <Version>4.8.0</Version>
@@ -489,27 +489,29 @@
       <Version>10.0.19041.1</Version>
     </PackageReference>
     <PackageReference Include="Microsoft.EntityFrameworkCore.Design">
-      <Version>3.1.9</Version>
+      <Version>3.1.13</Version>
+      <IncludeAssets>runtime; build; native; contentfiles; analyzers; buildtransitive</IncludeAssets>
+      <PrivateAssets>all</PrivateAssets>
     </PackageReference>
     <PackageReference Include="Microsoft.Xaml.Behaviors.Wpf">
-      <Version>1.1.19</Version>
+      <Version>1.1.31</Version>
     </PackageReference>
     <PackageReference Include="Notification.WPF">
       <Version>1.0.1.11</Version>
     </PackageReference>
     <PackageReference Include="NuGet.CommandLine">
-      <Version>5.8.0</Version>
+      <Version>5.8.1</Version>
       <IncludeAssets>runtime; build; native; contentfiles; analyzers; buildtransitive</IncludeAssets>
       <PrivateAssets>all</PrivateAssets>
     </PackageReference>
     <PackageReference Include="Octokit">
-      <Version>0.48.0</Version>
+      <Version>0.50.0</Version>
     </PackageReference>
     <PackageReference Include="QueryString.NET">
       <Version>1.0.0</Version>
     </PackageReference>
     <PackageReference Include="ReactiveUI.WPF">
-      <Version>13.0.27</Version>
+      <Version>13.2.2</Version>
     </PackageReference>
     <PackageReference Include="Squirrel.Windows">
       <Version>1.9.1</Version>

--- a/GroupMeClient.WpfUI/Notifications/Display/Win7/SingularNotificationManager.cs
+++ b/GroupMeClient.WpfUI/Notifications/Display/Win7/SingularNotificationManager.cs
@@ -1,7 +1,9 @@
 ﻿using System;
+using System.Threading;
 using System.Windows;
 using System.Windows.Threading;
 using Notification.Wpf;
+using Notification.Wpf.Classes;
 using Notification.Wpf.Controls;
 
 namespace GroupMeClient.WpfUI.Notifications.Display.Win7
@@ -47,7 +49,7 @@ namespace GroupMeClient.WpfUI.Notifications.Display.Win7
         private Dispatcher Dispatcher { get; }
 
         /// <inheritdoc/>
-        public void Show(object content, string areaName = "", TimeSpan? expirationTime = null, Action onClick = null, Action onClose = null)
+        public void Show(object content, string areaName = "", TimeSpan? expirationTime = null, Action onClick = null, Action onClose = null, bool CloseOnClick = true)
         {
             if (!this.Dispatcher.CheckAccess())
             {
@@ -68,8 +70,21 @@ namespace GroupMeClient.WpfUI.Notifications.Display.Win7
                     content,
                     expirationTime ?? TimeSpan.FromSeconds(5),
                     onClick,
-                    onClose);
+                    onClose,
+                    CloseOnClick);
             }
+        }
+
+        /// <inheritdoc/>
+        public void Show(string title, string message, NotificationType type, string areaName = "", TimeSpan? expirationTime = null, Action onClick = null, Action onClose = null, Action LeftButton = null, string LeftButtonText = null, Action RightButton = null, string RightButtonText = null, NotificationTextTrimType trim = NotificationTextTrimType.NoTrim, uint RowsCountWhenTrim = 2, bool CloseOnClick = true)
+        {
+            throw new NotImplementedException();
+        }
+
+        /// <inheritdoc/>
+        public void ShowProgressBar(out ProgressFinaly<(int? value, string message, string title, bool? showCancel)> progress, out CancellationToken Cancel, string Title = null, bool ShowCancelButton = true, bool ShowProgress = true, string areaName = "", bool TrimText = false, uint DefaultRowsCount = 1, string BaseWaitingMessage = "Calculation time")
+        {
+            throw new NotImplementedException();
         }
     }
 }


### PR DESCRIPTION
GroupMeClient.Core:
- Update EF Core to 3.1.13
- Update NuGet CLI Tools
- Update ReactiveUI
- Update Octokit
- Install SQLitePCLRaw.bundle_e_sqlite3 v2.0.4 for the fixes in ericsink/SQLitePCL.raw#321. The EF Core package still references v2.0.2.

GroupMeClient.WpfUI
- Update MahApps Metro
- Update Notifications.Wpf for Windows 7 notifications
- Update Reactive
- Update Octokit, NuGet CLI, and Xaml.Behaviors.