### PR TITLE
Feature/markdown messages

### DIFF
--- a/GroupMeClient.Core/Controls/Documents/MarkdownMessage.cs
+++ b/GroupMeClient.Core/Controls/Documents/MarkdownMessage.cs
@@ -1,0 +1,24 @@
+﻿using System;
+
+namespace GroupMeClient.Core.Controls.Documents
+{
+    /// <summary>
+    /// A section of text that should be processed as Markdown.
+    /// </summary>
+    public class MarkdownMessage : Inline
+    {
+        /// <summary>
+        /// Initializes a new instance of the <see cref="MarkdownMessage"/> class.
+        /// </summary>
+        /// <param name="content">The markdown contents.</param>
+        public MarkdownMessage(string content)
+        {
+            this.Content = content;
+        }
+
+        /// <summary>
+        /// Gets the markdown formatted contents.
+        /// </summary>
+        public string Content { get; }
+    }
+}

--- a/GroupMeClient.Core/Services/IClientIdentityService.cs
+++ b/GroupMeClient.Core/Services/IClientIdentityService.cs
@@ -26,6 +26,11 @@ namespace GroupMeClient.Core.Services
         string ClientGuidReplyPrefix { get; }
 
         /// <summary>
+        /// Gets the GUID prefix used for Markdown messages.
+        /// </summary>
+        string ClientGuidMarkdownPrefix { get; }
+
+        /// <summary>
         /// Gets the GUID prefix used for messages being quickly sent through interactive notifications.
         /// </summary>
         string ClientGuidQuickResponsePrefix { get; }

--- a/GroupMeClient.Core/Services/KnownClients/GMDC.cs
+++ b/GroupMeClient.Core/Services/KnownClients/GMDC.cs
@@ -21,6 +21,11 @@
         public static string GMDCGuidReplyPrefix => "gmdc-r";
 
         /// <summary>
+        /// Gets the guid prefix applied to all messages sent with markdown format from GMDC.
+        /// </summary>
+        public static string GMDCGuidMarkdownPrefix => "gmdc-m";
+
+        /// <summary>
         /// Gets the guid prefix applied to all messages sent from GMDC Toast Notifications.
         /// </summary>
         public static string GMDCGuidQuickResponsePrefix => "gmdctoast";
@@ -38,6 +43,9 @@
 
         /// <inheritdoc/>
         public string ClientGuidReplyPrefix => GMDCGuidReplyPrefix;
+
+        /// <inheritdoc/>
+        public string ClientGuidMarkdownPrefix => GMDCGuidMarkdownPrefix;
 
         /// <inheritdoc/>
         public string ClientGuidQuickResponsePrefix => GMDCGuidQuickResponsePrefix;

--- a/GroupMeClient.Core/Services/KnownClients/GMDCA.cs
+++ b/GroupMeClient.Core/Services/KnownClients/GMDCA.cs
@@ -21,6 +21,11 @@
         public static string GMDCAGuidReplyPrefix => "gmdca-r";
 
         /// <summary>
+        /// Gets the guid prefix applied to all messages sent as responses from GMDC.
+        /// </summary>
+        public static string GMDCAGuidMarkdownPrefix => "gmdca-m";
+
+        /// <summary>
         /// Gets the guid prefix applied to all messages sent from GMDC Toast Notifications.
         /// </summary>
         public static string GMDCAGuidQuickResponsePrefix => "gmdcatoast";
@@ -38,6 +43,9 @@
 
         /// <inheritdoc/>
         public string ClientGuidReplyPrefix => GMDCAGuidReplyPrefix;
+
+        /// <inheritdoc/>
+        public string ClientGuidMarkdownPrefix => GMDCAGuidMarkdownPrefix;
 
         /// <inheritdoc/>
         public string ClientGuidQuickResponsePrefix => GMDCAGuidQuickResponsePrefix;

--- a/GroupMeClient.Core/Services/ReleaseInfo.cs
+++ b/GroupMeClient.Core/Services/ReleaseInfo.cs
@@ -1,4 +1,5 @@
-﻿using System;
+﻿using GroupMeClient.Core.Controls.Documents;
+using System;
 using System.Collections.Generic;
 using System.Text;
 
@@ -17,7 +18,12 @@ namespace GroupMeClient.Core.Services
         /// <summary>
         /// Gets or sets the release notes for this release.
         /// </summary>
-        public string ReleaseNotes { get; set; }
+        public string ReleaseNotesText { get; set; }
+
+        /// <summary>
+        /// Gets or sets the formatted release notes for this release.
+        /// </summary>
+        public IEnumerable<Inline> ReleaseNotes { get; set; }
 
         /// <summary>
         /// Gets or sets a value indicating whether this version is a pre-release.

--- a/GroupMeClient.Core/Utilities/MessageUtils.cs
+++ b/GroupMeClient.Core/Utilities/MessageUtils.cs
@@ -66,5 +66,30 @@ namespace GroupMeClient.Core.Utilities
                 IsReplyGen2(message) ||
                 IsReplyGen1(message);
         }
+
+        /// <summary>
+        /// Determines if a specific <see cref="Message"/> is sent using the GMDC-specific Markdown formatting extensions.
+        /// This method tests for Markdown sent using any generation of the GMDC client.
+        /// </summary>
+        /// <param name="message">The message to check for being in Markdown.</param>
+        /// <returns>True if the given <see cref="Message"/> is in Markdown, otherwise, false.</returns>
+        public static bool IsGMDCMarkdown(Message message)
+        {
+            string[] knownClientReplyPrefixes =
+            {
+                Services.KnownClients.GMDC.GMDCGuidMarkdownPrefix,
+                Services.KnownClients.GMDCA.GMDCAGuidMarkdownPrefix,
+            };
+
+            foreach (var clientPrefix in knownClientReplyPrefixes)
+            {
+                if (message.SourceGuid.StartsWith(clientPrefix))
+                {
+                    return true;
+                }
+            }
+
+            return false;
+        }
     }
 }

--- a/GroupMeClient.WpfUI/App.xaml
+++ b/GroupMeClient.WpfUI/App.xaml
@@ -31,6 +31,7 @@
                 <ResourceDictionary Source="pack://application:,,,/Styles/GroupNameDropdown.xaml" />
                 <ResourceDictionary Source="pack://application:,,,/Styles/CopyableHyperlink.xaml" />
                 <ResourceDictionary Source="pack://application:,,,/Styles/MessageControlResources.xaml" />
+                <ResourceDictionary Source="pack://application:,,,/Styles/MarkdownStyles.xaml" />
                 <ResourceDictionary Source="pack://application:,,,/Styles/PopupDialog.xaml" />
                 <ResourceDictionary Source="pack://application:,,,/Styles/ScrollBar.xaml" />
                 <ResourceDictionary Source="pack://application:,,,/Styles/SendTextBox.xaml" />

--- a/GroupMeClient.WpfUI/Converters/Core/GMDCInlineToWPFInline.cs
+++ b/GroupMeClient.WpfUI/Converters/Core/GMDCInlineToWPFInline.cs
@@ -1,9 +1,9 @@
 ﻿using System;
 using System.Collections.Generic;
 using System.Collections.ObjectModel;
-using System.Linq;
 using System.Windows.Controls;
 using System.Windows.Data;
+using System.Windows.Input;
 using GroupMeClient.Core.Services;
 using GroupMeClient.WpfUI.Extensions;
 using GroupMeClient.WpfUI.Markdown;
@@ -72,12 +72,16 @@ namespace GroupMeClient.WpfUI.Converters
                         Document = doc,
                         Background = System.Windows.Media.Brushes.Transparent,
                         IsReadOnly = true,
+                        IsDocumentEnabled = true,
                         VerticalScrollBarVisibility = ScrollBarVisibility.Disabled,
                         HorizontalScrollBarVisibility = ScrollBarVisibility.Disabled,
                         BorderThickness = new System.Windows.Thickness(0),
                         Padding = new System.Windows.Thickness(0),
                         Margin = new System.Windows.Thickness(0),
                     };
+
+                    reader.CommandBindings.Add(new CommandBinding(MarkdownXaml.Hyperlink, new ExecutedRoutedEventHandler(this.HyperlinkHandler)));
+
                     var wrapper = new System.Windows.Documents.InlineUIContainer(reader);
                     return wrapper;
                 }
@@ -126,11 +130,7 @@ namespace GroupMeClient.WpfUI.Converters
                 NavigateUri = hyperlink.NavigateUri,
             };
 
-            result.RequestNavigate += (object sender, System.Windows.Navigation.RequestNavigateEventArgs e) =>
-            {
-                var osService = Ioc.Default.GetService<IOperatingSystemUIService>();
-                osService.OpenWebBrowser(hyperlink.NavigateUri.ToString());
-            };
+            result.RequestNavigate += this.HyperlinkHandler;
 
             return result;
         }
@@ -149,6 +149,25 @@ namespace GroupMeClient.WpfUI.Converters
                 default:
                     return System.Windows.FontWeights.Regular;
             }
+        }
+
+        private void HyperlinkHandler(object sender, ExecutedRoutedEventArgs e)
+        {
+            if (e.Parameter is Uri uri)
+            {
+                this.HyperlinkHandler(uri);
+            }
+        }
+
+        private void HyperlinkHandler(object sender, System.Windows.Navigation.RequestNavigateEventArgs e)
+        {
+            this.HyperlinkHandler(e.Uri);
+        }
+
+        private void HyperlinkHandler(Uri uri)
+        {
+            var osService = Ioc.Default.GetService<IOperatingSystemUIService>();
+            osService.OpenWebBrowser(uri.ToString());
         }
     }
 }

--- a/GroupMeClient.WpfUI/GroupMeClient.WpfUI.csproj
+++ b/GroupMeClient.WpfUI/GroupMeClient.WpfUI.csproj
@@ -488,6 +488,9 @@
     <PackageReference Include="MahApps.Metro.IconPacks.Octicons">
       <Version>4.8.0</Version>
     </PackageReference>
+    <PackageReference Include="Markdig">
+      <Version>0.25.0</Version>
+    </PackageReference>
     <PackageReference Include="Microsoft.Extensions.DependencyInjection">
       <Version>5.0.1</Version>
     </PackageReference>

--- a/GroupMeClient.WpfUI/GroupMeClient.WpfUI.csproj
+++ b/GroupMeClient.WpfUI/GroupMeClient.WpfUI.csproj
@@ -82,6 +82,9 @@
     <Compile Include="Extensions\NotRightClickTrigger.cs" />
     <Compile Include="Extensions\SetFocusBehavior.cs" />
     <Compile Include="GlobalAssemblyInfo.cs" />
+    <Compile Include="Markdown\GMDCMarkdown.cs" />
+    <Compile Include="Markdown\GMDCMarkdownStyle.cs" />
+    <Compile Include="Markdown\GMDCXamlMarkdownWriter.cs" />
     <Compile Include="Native\WindowsThemeUtils.cs" />
     <Compile Include="Notifications\Display\NativeDesktopNotificationProvider.cs" />
     <Compile Include="Plugins\ImageGalleryPlugin.cs" />
@@ -243,6 +246,10 @@
       <Generator>MSBuild:Compile</Generator>
     </Page>
     <Page Include="Styles\CopyableHyperlink.xaml">
+      <SubType>Designer</SubType>
+      <Generator>MSBuild:Compile</Generator>
+    </Page>
+    <Page Include="Styles\MarkdownStyles.xaml">
       <SubType>Designer</SubType>
       <Generator>MSBuild:Compile</Generator>
     </Page>
@@ -500,6 +507,9 @@
     </PackageReference>
     <PackageReference Include="Microsoft.Xaml.Behaviors.Wpf">
       <Version>1.1.31</Version>
+    </PackageReference>
+    <PackageReference Include="Neo.Markdig.Xaml">
+      <Version>1.0.10</Version>
     </PackageReference>
     <PackageReference Include="Notification.WPF">
       <Version>2.0.0.8</Version>

--- a/GroupMeClient.WpfUI/MainWindow.xaml
+++ b/GroupMeClient.WpfUI/MainWindow.xaml
@@ -26,6 +26,11 @@
         <viewModels:MainViewModel />
     </Window.DataContext>
 
+    <Window.InputBindings>
+        <KeyBinding Command="{Binding RefreshEverythingCommand}"
+                    Gesture="CTRL+R" />
+    </Window.InputBindings>
+
     <Window.Resources>
         <DataTemplate x:Key="OverlayIcon">
             <Grid Width="16" Height="16">

--- a/GroupMeClient.WpfUI/Markdown/GMDCMarkdown.cs
+++ b/GroupMeClient.WpfUI/Markdown/GMDCMarkdown.cs
@@ -1,0 +1,106 @@
+﻿using System;
+using System.IO;
+using System.Windows.Documents;
+using System.Xaml;
+using Markdig;
+
+namespace GroupMeClient.WpfUI.Markdown
+{
+    /// <summary>
+    /// Helper class for converting markdown text into WPF <see cref="FlowDocument"/> and XAML elements with GMDC styling.
+    /// </summary>
+    /// <remarks>
+    /// Adapted from https://raw.githubusercontent.com/neolithos/NeoMarkdigXaml/master/NeoMarkdigXaml/MarkdownXaml.cs.
+    /// </remarks>
+    internal static class GMDCMarkdown
+    {
+        /// <summary>Converts a Markdown string to a FlowDocument.</summary>
+        /// <param name="markdown">A Markdown text.</param>
+        /// <param name="pipeline">The pipeline used for the conversion.</param>
+        /// <param name="baseUri">Base uri for images and links.</param>
+        /// <returns>The result of the conversion.</returns>
+        /// <exception cref="System.ArgumentNullException">if markdown variable is null.</exception>
+        public static FlowDocument ToFlowDocument(string markdown, MarkdownPipeline pipeline = null, Uri baseUri = null)
+        {
+            if (markdown == null)
+            {
+                throw new ArgumentNullException(nameof(markdown));
+            }
+
+            if (pipeline == null)
+            {
+                pipeline = new MarkdownPipelineBuilder().Build();
+            }
+
+            using (var writer = new XamlObjectWriter(System.Windows.Markup.XamlReader.GetWpfSchemaContext()))
+            {
+                return (FlowDocument)ToXaml(markdown, writer, pipeline, baseUri);
+            }
+        }
+
+        /// <summary>Converts a Markdown string to XAML.</summary>
+        /// <param name="markdown">A Markdown text.</param>
+        /// <param name="pipeline">The pipeline used for the conversion.</param>
+        /// <param name="baseUri">Base uri for images and links.</param>
+        /// <returns>The result of the conversion.</returns>
+        /// <exception cref="ArgumentNullException">if markdown variable is null.</exception>
+        public static string ToXaml(string markdown, MarkdownPipeline pipeline = null, Uri baseUri = null)
+        {
+            if (markdown == null)
+            {
+                throw new ArgumentNullException(nameof(markdown));
+            }
+
+            using (var writer = new StringWriter())
+            {
+                ToXaml(markdown, writer, pipeline, baseUri);
+                return writer.ToString();
+            }
+        } // func ToXaml
+
+        /// <summary>Converts a Markdown string to XAML and output to the specified writer.</summary>
+        /// <param name="markdown">A Markdown text.</param>
+        /// <param name="writer">The destination <see cref="TextWriter"/> that will receive the result of the conversion.</param>
+        /// <param name="pipeline">The pipeline used for the conversion.</param>
+        /// <param name="baseUri">Base uri for images and links.</param>
+        public static void ToXaml(string markdown, TextWriter writer, MarkdownPipeline pipeline = null, Uri baseUri = null)
+        {
+            if (markdown == null)
+            {
+                throw new ArgumentNullException(nameof(markdown));
+            }
+
+            if (writer == null)
+            {
+                throw new ArgumentNullException(nameof(writer));
+            }
+
+            using (var xamlWriter = new XamlXmlWriter(writer, System.Windows.Markup.XamlReader.GetWpfSchemaContext(), new XamlXmlWriterSettings() { CloseOutput = false }))
+            {
+                ToXaml(markdown, xamlWriter, pipeline, baseUri);
+                xamlWriter.Flush();
+            }
+        }
+
+        /// <summary>Converts a Markdown string to XAML and output to the specified writer.</summary>
+        /// <param name="markdown">A Markdown text.</param>
+        /// <param name="writer">The destination <see cref="TextWriter"/> that will receive the result of the conversion.</param>
+        /// <param name="pipeline">The pipeline used for the conversion.</param>
+        /// <param name="baseUri">Base uri for images and links.</param>
+        /// <returns>Rendered XAML.</returns>
+        public static object ToXaml(string markdown, XamlWriter writer, MarkdownPipeline pipeline = null, Uri baseUri = null)
+        {
+            if (writer == null)
+            {
+                throw new ArgumentNullException(nameof(writer));
+            }
+
+            pipeline = pipeline ?? new MarkdownPipelineBuilder().Build();
+
+            var renderer = new GMDCXamlMarkdownWriter(writer) { BaseUri = baseUri };
+            pipeline.Setup(renderer);
+            var document = global::Markdig.Markdown.Parse(markdown, pipeline);
+            return renderer.Render(document);
+        }
+    }
+}

--- a/GroupMeClient.WpfUI/Markdown/GMDCMarkdownStyle.cs
+++ b/GroupMeClient.WpfUI/Markdown/GMDCMarkdownStyle.cs
@@ -92,13 +92,6 @@ namespace GroupMeClient.WpfUI.Markdown
         [EditorBrowsable(EditorBrowsableState.Advanced)]
         public static ResourceKey ThematicBreakStyleKey { get; } = CreateResourceKey(nameof(ThematicBreakStyleKey));
 
-        /// <summary>Gets a resource key for the HyperLinkStyle.</summary>
-        [EditorBrowsable(EditorBrowsableState.Advanced)]
-        public static ResourceKey HyperlinkStyleKey { get; } = CreateResourceKey(nameof(HyperlinkStyleKey));
-
-        /// <summary>Routed command for Hyperlink.</summary>
-        //public static RoutedCommand Hyperlink { get; } = CreateResourceKey(nameof(Hyperlink), typeof(GMDCMarkdownStyle));
-
         private static ComponentResourceKey CreateResourceKey(string caller = null)
         {
             return new ComponentResourceKey(typeof(GMDCMarkdownStyle), caller);

--- a/GroupMeClient.WpfUI/Markdown/GMDCMarkdownStyle.cs
+++ b/GroupMeClient.WpfUI/Markdown/GMDCMarkdownStyle.cs
@@ -1,0 +1,107 @@
+﻿using System.ComponentModel;
+using System.Windows;
+
+namespace GroupMeClient.WpfUI.Markdown
+{
+    /// <summary>
+    /// Resource keys with GMDC styling for markdown elements.
+    /// </summary>
+    internal static class GMDCMarkdownStyle
+    {
+        /// <summary>Gets a resource Key for the DocumentStyle.</summary>
+        [EditorBrowsable(EditorBrowsableState.Advanced)]
+        public static ResourceKey DocumentStyleKey { get; } = CreateResourceKey(nameof(DocumentStyleKey));
+
+        /// <summary>Gets a resource Key for the CodeStyle.</summary>
+        [EditorBrowsable(EditorBrowsableState.Advanced)]
+        public static ResourceKey CodeStyleKey { get; } = CreateResourceKey(nameof(CodeStyleKey));
+
+        /// <summary>Gets a resource Key for the CodeBlockStyle.</summary>
+        [EditorBrowsable(EditorBrowsableState.Advanced)]
+        public static ResourceKey CodeBlockStyleKey { get; } = CreateResourceKey(nameof(CodeBlockStyleKey));
+
+        /// <summary>Gets a resource Key for the Heading1Style.</summary>
+        [EditorBrowsable(EditorBrowsableState.Advanced)]
+        public static ResourceKey Heading1StyleKey { get; } = CreateResourceKey(nameof(Heading1StyleKey));
+
+        /// <summary>Gets a resource Key for the Heading2Style.</summary>
+        [EditorBrowsable(EditorBrowsableState.Advanced)]
+        public static ResourceKey Heading2StyleKey { get; } = CreateResourceKey(nameof(Heading2StyleKey));
+
+        /// <summary>Gets a resource Key for the Heading3Style.</summary>
+        [EditorBrowsable(EditorBrowsableState.Advanced)]
+        public static ResourceKey Heading3StyleKey { get; } = CreateResourceKey(nameof(Heading3StyleKey));
+
+        /// <summary>Gets a resource Key for the Heading4Style.</summary>
+        [EditorBrowsable(EditorBrowsableState.Advanced)]
+        public static ResourceKey Heading4StyleKey { get; } = CreateResourceKey(nameof(Heading4StyleKey));
+
+        /// <summary>Gets a resource Key for the Heading5Style.</summary>
+        [EditorBrowsable(EditorBrowsableState.Advanced)]
+        public static ResourceKey Heading5StyleKey { get; } = CreateResourceKey(nameof(Heading5StyleKey));
+
+        /// <summary>Gets a resource Key for the Heading6Style.</summary>
+        [EditorBrowsable(EditorBrowsableState.Advanced)]
+        public static ResourceKey Heading6StyleKey { get; } = CreateResourceKey(nameof(Heading6StyleKey));
+
+        /// <summary>Gets a resource Key for the ImageStyle.</summary>
+        [EditorBrowsable(EditorBrowsableState.Advanced)]
+        public static ResourceKey ImageStyleKey { get; } = CreateResourceKey(nameof(ImageStyleKey));
+
+        /// <summary>Gets a resource Key for the InsertedStyle.</summary>
+        [EditorBrowsable(EditorBrowsableState.Advanced)]
+        public static ResourceKey InsertedStyleKey { get; } = CreateResourceKey(nameof(InsertedStyleKey));
+
+        /// <summary>Gets a resource Key for the MarkedStyle.</summary>
+        [EditorBrowsable(EditorBrowsableState.Advanced)]
+        public static ResourceKey MarkedStyleKey { get; } = CreateResourceKey(nameof(MarkedStyleKey));
+
+        /// <summary>Gets a resource Key for the QuoteBlockStyle.</summary>
+        [EditorBrowsable(EditorBrowsableState.Advanced)]
+        public static ResourceKey QuoteBlockStyleKey { get; } = CreateResourceKey(nameof(QuoteBlockStyleKey));
+
+        /// <summary>Gets a resource Key for the StrikeThroughStyle.</summary>
+        [EditorBrowsable(EditorBrowsableState.Advanced)]
+        public static ResourceKey StrikeThroughStyleKey { get; } = CreateResourceKey(nameof(StrikeThroughStyleKey));
+
+        /// <summary>Gets a resource Key for the SubscriptStyle.</summary>
+        [EditorBrowsable(EditorBrowsableState.Advanced)]
+        public static ResourceKey SubscriptStyleKey { get; } = CreateResourceKey(nameof(SubscriptStyleKey));
+
+        /// <summary>Gets a resource Key for the SuperscriptStyle.</summary>
+        [EditorBrowsable(EditorBrowsableState.Advanced)]
+        public static ResourceKey SuperscriptStyleKey { get; } = CreateResourceKey(nameof(SuperscriptStyleKey));
+
+        /// <summary>Gets a resource Key for the TableStyle.</summary>
+        [EditorBrowsable(EditorBrowsableState.Advanced)]
+        public static ResourceKey TableStyleKey { get; } = CreateResourceKey(nameof(TableStyleKey));
+
+        /// <summary>Gets a resource Key for the TableCellStyle.</summary>
+        [EditorBrowsable(EditorBrowsableState.Advanced)]
+        public static ResourceKey TableCellStyleKey { get; } = CreateResourceKey(nameof(TableCellStyleKey));
+
+        /// <summary>Gets a resource Key for the TableHeaderStyle.</summary>
+        [EditorBrowsable(EditorBrowsableState.Advanced)]
+        public static ResourceKey TableHeaderStyleKey { get; } = CreateResourceKey(nameof(TableHeaderStyleKey));
+
+        /// <summary>Gets a resource Key for the TaskListStyle.</summary>
+        [EditorBrowsable(EditorBrowsableState.Advanced)]
+        public static ResourceKey TaskListStyleKey { get; } = CreateResourceKey(nameof(TaskListStyleKey));
+
+        /// <summary>Gets a resource Key for the ThematicBreakStyle.</summary>
+        [EditorBrowsable(EditorBrowsableState.Advanced)]
+        public static ResourceKey ThematicBreakStyleKey { get; } = CreateResourceKey(nameof(ThematicBreakStyleKey));
+
+        /// <summary>Gets a resource key for the HyperLinkStyle.</summary>
+        [EditorBrowsable(EditorBrowsableState.Advanced)]
+        public static ResourceKey HyperlinkStyleKey { get; } = CreateResourceKey(nameof(HyperlinkStyleKey));
+
+        /// <summary>Routed command for Hyperlink.</summary>
+        //public static RoutedCommand Hyperlink { get; } = CreateResourceKey(nameof(Hyperlink), typeof(GMDCMarkdownStyle));
+
+        private static ComponentResourceKey CreateResourceKey(string caller = null)
+        {
+            return new ComponentResourceKey(typeof(GMDCMarkdownStyle), caller);
+        }
+    }
+}

--- a/GroupMeClient.WpfUI/Markdown/GMDCXamlMarkdownWriter.cs
+++ b/GroupMeClient.WpfUI/Markdown/GMDCXamlMarkdownWriter.cs
@@ -1,0 +1,76 @@
+﻿using System;
+using System.Xaml;
+using Neo.Markdig.Xaml;
+using Neo.Markdig.Xaml.Renderers;
+
+namespace GroupMeClient.WpfUI.Markdown
+{
+    /// <summary>
+    /// An implementation of <see cref="XamlMarkdownWriter"/> that uses GMDC styling.
+    /// </summary>
+    internal class GMDCXamlMarkdownWriter : XamlMarkdownWriter
+    {
+        /// <summary>
+        /// Initializes a new instance of the <see cref="GMDCXamlMarkdownWriter"/> class.
+        /// </summary>
+        /// <param name="writer">The XAML writer to emit the rendered document to.</param>
+        public GMDCXamlMarkdownWriter(XamlWriter writer)
+            : base(writer)
+        {
+        }
+
+        /// <inheritdoc/>
+        public override object GetDefaultStyle(MarkdownXamlStyle style)
+        {
+            switch (style)
+            {
+                case MarkdownXamlStyle.Document:
+                    return GMDCMarkdownStyle.DocumentStyleKey;
+                case MarkdownXamlStyle.Code:
+                    return GMDCMarkdownStyle.CodeStyleKey;
+                case MarkdownXamlStyle.CodeBlock:
+                    return GMDCMarkdownStyle.CodeBlockStyleKey;
+                case MarkdownXamlStyle.Heading1:
+                    return GMDCMarkdownStyle.Heading1StyleKey;
+                case MarkdownXamlStyle.Heading2:
+                    return GMDCMarkdownStyle.Heading2StyleKey;
+                case MarkdownXamlStyle.Heading3:
+                    return GMDCMarkdownStyle.Heading3StyleKey;
+                case MarkdownXamlStyle.Heading4:
+                    return GMDCMarkdownStyle.Heading4StyleKey;
+                case MarkdownXamlStyle.Heading5:
+                    return GMDCMarkdownStyle.Heading5StyleKey;
+                case MarkdownXamlStyle.Heading6:
+                    return GMDCMarkdownStyle.Heading6StyleKey;
+                case MarkdownXamlStyle.Image:
+                    return GMDCMarkdownStyle.ImageStyleKey;
+                case MarkdownXamlStyle.Inserted:
+                    return GMDCMarkdownStyle.InsertedStyleKey;
+                case MarkdownXamlStyle.Marked:
+                    return GMDCMarkdownStyle.MarkedStyleKey;
+                case MarkdownXamlStyle.QuoteBlock:
+                    return GMDCMarkdownStyle.QuoteBlockStyleKey;
+                case MarkdownXamlStyle.StrikeThrough:
+                    return GMDCMarkdownStyle.StrikeThroughStyleKey;
+                case MarkdownXamlStyle.Subscript:
+                    return GMDCMarkdownStyle.SubscriptStyleKey;
+                case MarkdownXamlStyle.Superscript:
+                    return GMDCMarkdownStyle.SuperscriptStyleKey;
+                case MarkdownXamlStyle.Table:
+                    return GMDCMarkdownStyle.TableStyleKey;
+                case MarkdownXamlStyle.TableCell:
+                    return GMDCMarkdownStyle.TableCellStyleKey;
+                case MarkdownXamlStyle.TableHeader:
+                    return GMDCMarkdownStyle.TableHeaderStyleKey;
+                case MarkdownXamlStyle.TaskList:
+                    return GMDCMarkdownStyle.TaskListStyleKey;
+                case MarkdownXamlStyle.ThematicBreak:
+                    return GMDCMarkdownStyle.ThematicBreakStyleKey;
+                case MarkdownXamlStyle.Hyperlink:
+                    return GMDCMarkdownStyle.HyperlinkStyleKey;
+                default:
+                    throw new ArgumentOutOfRangeException(nameof(style));
+            }
+        }
+    }
+}

--- a/GroupMeClient.WpfUI/Markdown/GMDCXamlMarkdownWriter.cs
+++ b/GroupMeClient.WpfUI/Markdown/GMDCXamlMarkdownWriter.cs
@@ -66,8 +66,6 @@ namespace GroupMeClient.WpfUI.Markdown
                     return GMDCMarkdownStyle.TaskListStyleKey;
                 case MarkdownXamlStyle.ThematicBreak:
                     return GMDCMarkdownStyle.ThematicBreakStyleKey;
-                case MarkdownXamlStyle.Hyperlink:
-                    return GMDCMarkdownStyle.HyperlinkStyleKey;
                 default:
                     throw new ArgumentOutOfRangeException(nameof(style));
             }

--- a/GroupMeClient.WpfUI/Styles/GroupMeDark.xaml
+++ b/GroupMeClient.WpfUI/Styles/GroupMeDark.xaml
@@ -24,6 +24,7 @@
     <Color x:Key="PluginMenuColor">#000000</Color>
     <Color x:Key="FileIconColor">#FFFFFF</Color>
     <Color x:Key="InProgressReplyColor">#000000</Color>
+    <Color x:Key="CodeSpanShadeColor">#414A59</Color>
 
     <SolidColorBrush options:Freeze="True" x:Key="DividerLineBrush" Color="{DynamicResource DividerLineColor}"/>
     <SolidColorBrush options:Freeze="True" x:Key="MessageFontBrush" Color="{DynamicResource MessageFontColor}"/>
@@ -42,4 +43,5 @@
     <SolidColorBrush options:Freeze="True" x:Key="PluginMenuBrush" Color="{DynamicResource PluginMenuColor}" />
     <SolidColorBrush options:Freeze="True" x:Key="FileIconBrush" Color="{DynamicResource FileIconColor}" />
     <SolidColorBrush options:Freeze="True" x:Key="InProgressReplyBrush" Color="{DynamicResource InProgressReplyColor}" />
+    <SolidColorBrush options:Freeze="True" x:Key="CodeSpanShadeBrush" Color="{DynamicResource CodeSpanShadeColor}" />
 </ResourceDictionary>

--- a/GroupMeClient.WpfUI/Styles/GroupMeLight.xaml
+++ b/GroupMeClient.WpfUI/Styles/GroupMeLight.xaml
@@ -24,6 +24,7 @@
     <Color x:Key="PluginMenuColor">#FFFFFF</Color>
     <Color x:Key="FileIconColor">#1873BA</Color>
     <Color x:Key="InProgressReplyColor">#DDDDDD</Color>
+    <Color x:Key="CodeSpanShadeColor">#ffd3d3d3</Color>
 
     <SolidColorBrush options:Freeze="True" x:Key="DividerLineBrush" Color="{DynamicResource DividerLineColor}"/>
     <SolidColorBrush options:Freeze="True" x:Key="MessageFontBrush" Color="{DynamicResource MessageFontColor}"/>
@@ -42,4 +43,5 @@
     <SolidColorBrush options:Freeze="True" x:Key="PluginMenuBrush" Color="{DynamicResource PluginMenuColor}" />
     <SolidColorBrush options:Freeze="True" x:Key="FileIconBrush" Color="{DynamicResource FileIconColor}" />
     <SolidColorBrush options:Freeze="True" x:Key="InProgressReplyBrush" Color="{DynamicResource InProgressReplyColor}" />
+    <SolidColorBrush options:Freeze="True" x:Key="CodeSpanShadeBrush" Color="{DynamicResource CodeSpanShadeColor}" />
 </ResourceDictionary>

--- a/GroupMeClient.WpfUI/Styles/MarkdownStyles.xaml
+++ b/GroupMeClient.WpfUI/Styles/MarkdownStyles.xaml
@@ -7,6 +7,7 @@
         <Setter Property="FontFamily" Value="Segoe UI" />
         <Setter Property="TextAlignment" Value="Left" />
         <Setter Property="FontSize" Value="15" />
+        <Setter Property="LineHeight" Value="1" />
     </Style>
     
     <Style TargetType="{x:Type List}">
@@ -25,12 +26,7 @@
         <Setter Property="Foreground" Value="{DynamicResource MahApps.Brushes.Text}"/>
         <Setter Property="FontFamily" Value="Consolas, Lucida Sans Typewriter, Courier New" />
     </Style>
-    
-    <!--<Style TargetType="{x:Type Hyperlink}" x:Key="{x:Static mdxaml:GMDCMarkdownStyle.HyperlinkStyleKey}">
-        <Setter Property="Command" Value="{x:Static mdxaml:GMDCMarkdownStyle.Hyperlink}" />
-        <Setter Property="CommandParameter" Value="{Binding RelativeSource={RelativeSource Self}, Path=NavigateUri}" />
-    </Style>-->
-    
+
     <Style TargetType="{x:Type Paragraph}" x:Key="{x:Static mdxaml:GMDCMarkdownStyle.Heading1StyleKey}">
         <Setter Property="FontSize" Value="20" />
         <Setter Property="FontWeight" Value="Bold" />

--- a/GroupMeClient.WpfUI/Styles/MarkdownStyles.xaml
+++ b/GroupMeClient.WpfUI/Styles/MarkdownStyles.xaml
@@ -1,0 +1,121 @@
+﻿<ResourceDictionary xmlns="http://schemas.microsoft.com/winfx/2006/xaml/presentation"
+                    xmlns:x="http://schemas.microsoft.com/winfx/2006/xaml"
+                    xmlns:mdxaml="clr-namespace:GroupMeClient.WpfUI.Markdown" >
+
+    <!-- Document styles -->
+    <Style TargetType="{x:Type FlowDocument}" x:Key="{x:Static mdxaml:GMDCMarkdownStyle.DocumentStyleKey}">
+        <Setter Property="FontFamily" Value="Segoe UI" />
+        <Setter Property="TextAlignment" Value="Left" />
+        <Setter Property="FontSize" Value="15" />
+    </Style>
+    
+    <Style TargetType="{x:Type List}">
+        <Setter Property="Margin" Value="40,0,0,0" />
+        <Setter Property="Padding" Value="0,0,0,0" />
+    </Style>
+    
+    <Style TargetType="{x:Type Paragraph}" x:Key="{x:Static mdxaml:GMDCMarkdownStyle.CodeBlockStyleKey}">
+        <Setter Property="Background" Value="{DynamicResource CodeSpanShadeBrush}" />
+        <Setter Property="Foreground" Value="{DynamicResource MahApps.Brushes.Text}"/>
+        <Setter Property="FontFamily" Value="Consolas, Lucida Sans Typewriter, Courier New" />
+    </Style>
+    
+    <Style TargetType="{x:Type Span}" x:Key="{x:Static mdxaml:GMDCMarkdownStyle.CodeStyleKey}">
+        <Setter Property="Background" Value="{DynamicResource CodeSpanShadeBrush}" />
+        <Setter Property="Foreground" Value="{DynamicResource MahApps.Brushes.Text}"/>
+        <Setter Property="FontFamily" Value="Consolas, Lucida Sans Typewriter, Courier New" />
+    </Style>
+    
+    <!--<Style TargetType="{x:Type Hyperlink}" x:Key="{x:Static mdxaml:GMDCMarkdownStyle.HyperlinkStyleKey}">
+        <Setter Property="Command" Value="{x:Static mdxaml:GMDCMarkdownStyle.Hyperlink}" />
+        <Setter Property="CommandParameter" Value="{Binding RelativeSource={RelativeSource Self}, Path=NavigateUri}" />
+    </Style>-->
+    
+    <Style TargetType="{x:Type Paragraph}" x:Key="{x:Static mdxaml:GMDCMarkdownStyle.Heading1StyleKey}">
+        <Setter Property="FontSize" Value="20" />
+        <Setter Property="FontWeight" Value="Bold" />
+    </Style>
+    
+    <Style TargetType="{x:Type Paragraph}" x:Key="{x:Static mdxaml:GMDCMarkdownStyle.Heading2StyleKey}">
+        <Setter Property="FontSize" Value="16" />
+        <Setter Property="FontWeight" Value="Bold" />
+    </Style>
+    
+    <Style TargetType="{x:Type Paragraph}" x:Key="{x:Static mdxaml:GMDCMarkdownStyle.Heading3StyleKey}">
+        <Setter Property="FontSize" Value="14" />
+        <Setter Property="FontWeight" Value="Bold" />
+    </Style>
+    
+    <Style TargetType="{x:Type Paragraph}" x:Key="{x:Static mdxaml:GMDCMarkdownStyle.Heading4StyleKey}">
+        <Setter Property="FontSize" Value="14" />
+        <Setter Property="FontWeight" Value="Light" />
+        <Setter Property="TextDecorations" Value="Underline" />
+    </Style>
+    
+    <Style TargetType="{x:Type Paragraph}" x:Key="{x:Static mdxaml:GMDCMarkdownStyle.Heading5StyleKey}">
+        <!-- no changes -->
+    </Style>
+    
+    <Style TargetType="{x:Type Paragraph}" x:Key="{x:Static mdxaml:GMDCMarkdownStyle.Heading6StyleKey}">
+        <!-- no changes -->
+    </Style>
+    
+    <Style TargetType="{x:Type Image}" x:Key="{x:Static mdxaml:GMDCMarkdownStyle.ImageStyleKey}">
+        <Setter Property="MaxHeight" Value="{Binding RelativeSource={RelativeSource Self}, Path=Source.(BitmapSource.PixelHeight)}" />
+        <Setter Property="MaxWidth" Value="{Binding RelativeSource={RelativeSource Self}, Path=Source.(BitmapSource.PixelWidth)}" />
+    </Style>
+    
+    <Style TargetType="{x:Type Section}" x:Key="{x:Static mdxaml:GMDCMarkdownStyle.QuoteBlockStyleKey}">
+        <Setter Property="BorderBrush" Value="LightGray" />
+        <Setter Property="BorderThickness" Value="4,0,0,0" />
+        <Setter Property="Foreground" Value="Gray" />
+        <Setter Property="Padding" Value="16,0,0,0" />
+    </Style>
+    
+    <Style TargetType="{x:Type Table}" x:Key="{x:Static mdxaml:GMDCMarkdownStyle.TableStyleKey}">
+        <Setter Property="BorderBrush" Value="{DynamicResource MahApps.Brushes.Text}"/>
+        <Setter Property="BorderThickness" Value="0,0,1,1"/>
+        <Setter Property="CellSpacing" Value="0"/>
+    </Style>
+    
+    <Style TargetType="{x:Type TableCell}" x:Key="{x:Static mdxaml:GMDCMarkdownStyle.TableCellStyleKey}">
+        <Setter Property="BorderBrush" Value="{DynamicResource MahApps.Brushes.Text}"/>
+        <Setter Property="BorderThickness" Value="1,1,0,0"/>
+    </Style>
+    
+    <Style TargetType="{x:Type TableRow}" x:Key="{x:Static mdxaml:GMDCMarkdownStyle.TableHeaderStyleKey}">
+        <Setter Property="FontWeight" Value="Bold"/>
+    </Style>
+    
+    <Style TargetType="{x:Type CheckBox}" x:Key="{x:Static mdxaml:GMDCMarkdownStyle.TaskListStyleKey}">
+        <Setter Property="Margin" Value="0,0,0,-2" />
+    </Style>
+    
+    <Style TargetType="{x:Type Paragraph}" x:Key="{x:Static mdxaml:GMDCMarkdownStyle.ThematicBreakStyleKey}">
+        <Setter Property="BorderBrush" Value="DarkGray"/>
+        <Setter Property="BorderThickness" Value="0,0,0,1"/>
+        <Setter Property="LineHeight" Value="1" />
+        <Setter Property="Margin" Value="3cm,0" />
+    </Style>
+    
+    <Style TargetType="{x:Type Span}" x:Key="{x:Static mdxaml:GMDCMarkdownStyle.SubscriptStyleKey}">
+        <Setter Property="Typography.Variants" Value="Subscript" />
+    </Style>
+    
+    <Style TargetType="{x:Type Span}" x:Key="{x:Static mdxaml:GMDCMarkdownStyle.SuperscriptStyleKey}">
+        <Setter Property="Typography.Variants" Value="Superscript" />
+    </Style>
+    
+    <Style TargetType="{x:Type Span}" x:Key="{x:Static mdxaml:GMDCMarkdownStyle.StrikeThroughStyleKey}">
+        <Setter Property="TextBlock.TextDecorations" Value="Strikethrough" />
+    </Style>
+    
+    <Style TargetType="{x:Type Span}" x:Key="{x:Static mdxaml:GMDCMarkdownStyle.InsertedStyleKey}">
+        <Setter Property="TextBlock.TextDecorations" Value="Underline" />
+    </Style>
+    
+    <Style TargetType="{x:Type Span}" x:Key="{x:Static mdxaml:GMDCMarkdownStyle.MarkedStyleKey}">
+        <Setter Property="Background" Value="Yellow" />
+    </Style>
+    
+</ResourceDictionary>

--- a/GroupMeClient.WpfUI/Styles/MessageControlResources.xaml
+++ b/GroupMeClient.WpfUI/Styles/MessageControlResources.xaml
@@ -268,7 +268,7 @@
             </Canvas>
 
             <!--Message Right-Click Details-->
-            <StackPanel Grid.Row="3" Grid.Column="0" Grid.ColumnSpan="3"
+            <StackPanel Grid.Row="3" Grid.Column="0" Grid.ColumnSpan="5"
                         Orientation="Vertical"
                         Background="{DynamicResource MessageDetailsBrush}"
                         Height="45"
@@ -296,7 +296,7 @@
 
             <Button Grid.Row="3"
                     Grid.Column="0"
-                    Grid.ColumnSpan="3"
+                    Grid.ColumnSpan="5"
                     HorizontalAlignment="Right"
                     Visibility="{Binding ShowDetails, Converter={StaticResource boolToVisibilityConverter}}"
                     Command="{Binding ToggleMarkdown}" />

--- a/GroupMeClient.WpfUI/Styles/MessageControlResources.xaml
+++ b/GroupMeClient.WpfUI/Styles/MessageControlResources.xaml
@@ -54,16 +54,16 @@
                 <TextBlock Text="{Binding Sender, Mode=OneTime}" FontSize="12" Foreground="{DynamicResource DividerLineBrush}" />
 
                 <ContentControl Content="{Binding RepliedMessage}" 
-                                    HorizontalAlignment="Left"
-                                    Margin="0,0,10,10" 
-                                    Visibility="{Binding RepliedMessage, Converter={StaticResource nullToVisibilityConverter}, ConverterParameter={StaticResource True}}" />
+                                HorizontalAlignment="Left"
+                                Margin="0,0,10,10" 
+                                Visibility="{Binding RepliedMessage, Converter={StaticResource nullToVisibilityConverter}, ConverterParameter={StaticResource True}}" />
 
                 <ItemsControl ItemsSource="{Binding AttachedItems}">
                     <ItemsControl.ItemTemplate>
                         <DataTemplate>
                             <UserControl HorizontalAlignment="Left"
-                                             Content="{Binding .}"
-                                             MaxWidth="700" />
+                                         Content="{Binding .}"
+                                         MaxWidth="700" />
                         </DataTemplate>
                     </ItemsControl.ItemTemplate>
 
@@ -77,7 +77,7 @@
                 <extensions:SelectableTextBlock 
                         Padding="0"
                         Margin="0,0,0,20"
-                        FontSize="15" 
+                        FontSize="15"
                         TextWrapping="Wrap" 
                         extensions:TextBlockExtensions.InlineList="{Binding Inlines, Converter={StaticResource inlineConverter}, Mode=OneWay}">
 
@@ -93,15 +93,15 @@
 
             <!--Hidden Message Indicator-->
             <iconPacks:PackIconOcticons Width="15" Height="15"
-                                               Grid.Row="1"
-                                               Grid.Column="2"
-                                               VerticalAlignment="Top"
-                                               Margin="0,17,10,0"
-                                               HorizontalAlignment="Center"
-                                               Kind="X"
-                                               Visibility="{Binding IsMessageHidden, Converter={StaticResource boolToVisibilityConverter}}"
-                                               Foreground="Red"
-                                               Background="Transparent">
+                                        Grid.Row="1"
+                                        Grid.Column="2"
+                                        VerticalAlignment="Top"
+                                        Margin="0,17,10,0"
+                                        HorizontalAlignment="Center"
+                                        Kind="X"
+                                        Visibility="{Binding IsMessageHidden, Converter={StaticResource boolToVisibilityConverter}}"
+                                        Foreground="Red"
+                                        Background="Transparent">
                 <iconPacks:PackIconOcticons.ContextMenu>
                     <ContextMenu>
                         <MenuItem Command="{Binding DeHideAction}"
@@ -269,11 +269,11 @@
 
             <!--Message Right-Click Details-->
             <StackPanel Grid.Row="3" Grid.Column="0" Grid.ColumnSpan="3"
-                            Orientation="Vertical"
-                            Background="{DynamicResource MessageDetailsBrush}"
-                            Height="45"
-                            ContextMenu="{StaticResource emptyContextMenu}"
-                            Visibility="{Binding ShowDetails, Converter={StaticResource boolToVisibilityConverter}}">
+                        Orientation="Vertical"
+                        Background="{DynamicResource MessageDetailsBrush}"
+                        Height="45"
+                        ContextMenu="{StaticResource emptyContextMenu}"
+                        Visibility="{Binding ShowDetails, Converter={StaticResource boolToVisibilityConverter}}">
 
                 <behaviors:Interaction.Triggers>
                     <behaviors:EventTrigger EventName="MouseRightButtonUp" >
@@ -293,6 +293,13 @@
                                Foreground="{DynamicResource MessageFontBrush}"
                                Padding="20,0,0,0"/>
             </StackPanel>
+
+            <Button Grid.Row="3"
+                    Grid.Column="0"
+                    Grid.ColumnSpan="3"
+                    HorizontalAlignment="Right"
+                    Visibility="{Binding ShowDetails, Converter={StaticResource boolToVisibilityConverter}}"
+                    Command="{Binding ToggleMarkdown}" />
         </Grid>
     </DataTemplate>
 

--- a/GroupMeClient.WpfUI/Updates/UpdateAssist.cs
+++ b/GroupMeClient.WpfUI/Updates/UpdateAssist.cs
@@ -7,6 +7,7 @@ using System.Reactive.Subjects;
 using System.Reflection;
 using System.Threading;
 using System.Threading.Tasks;
+using GroupMeClient.Core.Controls.Documents;
 using GroupMeClient.Core.Services;
 using Microsoft.Toolkit.Mvvm.DependencyInjection;
 using Microsoft.Toolkit.Mvvm.Messaging;
@@ -71,7 +72,14 @@ namespace GroupMeClient.WpfUI.Updates
             var isNewest = true;
             foreach (var release in releases)
             {
-                results.Add(new ReleaseInfo() { Version = release.Name, ReleaseNotes = release.Body, PreRelease = release.Prerelease, IsLatest = isNewest });
+                results.Add(new ReleaseInfo()
+                {
+                    Version = release.Name,
+                    ReleaseNotesText = release.Body,
+                    ReleaseNotes = new List<Inline>() { new MarkdownMessage(release.Body) },
+                    PreRelease = release.Prerelease,
+                    IsLatest = isNewest,
+                });
                 isNewest = false;
             }
 

--- a/GroupMeClient.WpfUI/Views/Controls/GroupContentsControl.xaml
+++ b/GroupMeClient.WpfUI/Views/Controls/GroupContentsControl.xaml
@@ -34,6 +34,9 @@
     <UserControl.InputBindings>
         <KeyBinding Command="{Binding ToggleMarkdownMode}"
                     Gesture="CTRL+M" />
+
+        <KeyBinding Command="{Binding OpenMessageSuggestions}"
+                    Gesture="CTRL+E" />
     </UserControl.InputBindings>
 
     <Grid>

--- a/GroupMeClient.WpfUI/Views/Controls/GroupContentsControl.xaml
+++ b/GroupMeClient.WpfUI/Views/Controls/GroupContentsControl.xaml
@@ -34,9 +34,13 @@
     <UserControl.InputBindings>
         <KeyBinding Command="{Binding ToggleMarkdownMode}"
                     Gesture="CTRL+M" />
-
+        
         <KeyBinding Command="{Binding OpenMessageSuggestions}"
                     Gesture="CTRL+E" />
+
+        <KeyBinding Command="{Binding CloseGroup}"
+                    CommandParameter="{Binding Path=.}"
+                    Gesture="CTRL+W" />
     </UserControl.InputBindings>
 
     <Grid>
@@ -431,8 +435,6 @@
                         </Style.Triggers>
                     </Style>
                 </Button.Style>
-
-               
             </Button>
 
             <!--Message Text Box-->

--- a/GroupMeClient.WpfUI/Views/Controls/GroupContentsControl.xaml
+++ b/GroupMeClient.WpfUI/Views/Controls/GroupContentsControl.xaml
@@ -36,7 +36,6 @@
                     Gesture="CTRL+M" />
     </UserControl.InputBindings>
 
-
     <Grid>
         <Grid.ColumnDefinitions>
             <ColumnDefinition Width="*" />
@@ -244,8 +243,7 @@
                 CornerRadius="5"
                 BorderBrush="{DynamicResource DividerLineBrush}">
 
-            <TextBlock extensions:TextBlockExtensions.InlineList="{Binding TypedMessageContents, Converter={StaticResource inlineConverter}}"
-                       />
+            <TextBlock extensions:TextBlockExtensions.InlineList="{Binding TypedMessageContents, Converter={StaticResource inlineConverter}}"/>
         </Border>
 
         <!--Plugins Dropdown List-->
@@ -362,7 +360,7 @@
             </Grid.RowDefinitions>
 
             <!--Send Bar Top Line-->
-            <Border Grid.Column="0" Grid.Row="0" Grid.ColumnSpan="4"
+            <Border Grid.Column="0" Grid.Row="0" Grid.ColumnSpan="5"
                     BorderBrush="{DynamicResource DividerLineBrush}" BorderThickness="0,0,0,1"
                     Height="4"
                     Margin="0,0,0,0"
@@ -370,6 +368,7 @@
 
             <!--Box showing the message that is being replied to-->
             <Grid Grid.Column="1" 
+                  Grid.ColumnSpan="2"
                   HorizontalAlignment="Stretch" 
                   MaxHeight="100" 
                   Visibility="{Binding MessageBeingRepliedTo, Converter={StaticResource nullToVisibilityConverter}, ConverterParameter={StaticResource True}}"
@@ -378,7 +377,7 @@
                 <Border CornerRadius="2" BorderBrush="#637182" BorderThickness="2,2,2,0">
                     <Border CornerRadius="3" BorderBrush="{DynamicResource InProgressReplyBrush}" Margin="5,5,5,3" BorderThickness="2,2,2,2">
                         <UserControl Content="{Binding MessageBeingRepliedTo}"
-                                         Background="{DynamicResource InProgressReplyBrush}"/>
+                                     Background="{DynamicResource InProgressReplyBrush}"/>
                     </Border>
                 </Border>
 

--- a/GroupMeClient.WpfUI/Views/Controls/GroupContentsControl.xaml
+++ b/GroupMeClient.WpfUI/Views/Controls/GroupContentsControl.xaml
@@ -31,6 +31,12 @@
         </Style>
     </UserControl.Resources>
 
+    <UserControl.InputBindings>
+        <KeyBinding Command="{Binding ToggleMarkdownMode}"
+                    Gesture="CTRL+M" />
+    </UserControl.InputBindings>
+
+
     <Grid>
         <Grid.ColumnDefinitions>
             <ColumnDefinition Width="*" />
@@ -99,7 +105,6 @@
                         </Style.Triggers>
                     </Style>
                 </Button.Style>
-                
             </Button>
 
             <!--Refresh Group Button-->
@@ -229,6 +234,20 @@
             </Button.Content>
         </Button>
 
+        <!--Markdown Preview -->
+        <Border Grid.Row="2"
+                Visibility="{Binding IsMarkdownMode, Converter={StaticResource boolToVisibilityConverter}}"
+                VerticalAlignment="Top"
+                Background="{DynamicResource MahApps.Brushes.Control.Background}"
+                BorderThickness="2,2,2,2"
+                Margin="1,0,18,0"
+                CornerRadius="5"
+                BorderBrush="{DynamicResource DividerLineBrush}">
+
+            <TextBlock extensions:TextBlockExtensions.InlineList="{Binding TypedMessageContents, Converter={StaticResource inlineConverter}}"
+                       />
+        </Border>
+
         <!--Plugins Dropdown List-->
         <Border Grid.Row="2"
                 Visibility="{Binding IsChecked, ElementName=toggleGroupOptionsButton, Converter={StaticResource boolToVisibilityConverter}}"
@@ -332,6 +351,7 @@
               Background="{DynamicResource MahApps.Brushes.Control.Background}">
             <Grid.ColumnDefinitions>
                 <ColumnDefinition Width="40" />
+                <ColumnDefinition Width="20" />
                 <ColumnDefinition Width="*" />
                 <ColumnDefinition Width="Auto" />
                 <ColumnDefinition Width="Auto" />
@@ -383,9 +403,39 @@
                 <iconPacks:PackIconMaterial Kind="React" Width="15" Height="15" />
             </Button>
 
+            <!--Markdown Button-->
+            <Button Grid.Row="1" Grid.Column="1"
+                    Background="Transparent"
+                    Margin="0"
+                    Command="{Binding ToggleMarkdownMode}" >
+
+                <Button.Style>
+                    <Style TargetType="{x:Type Button}" BasedOn="{StaticResource bottomBarButtonStyle}">
+                        <Style.Triggers>
+                            <DataTrigger Binding="{Binding IsMarkdownMode}" Value="True">
+                                <Setter Property="Content">
+                                    <Setter.Value>
+                                        <iconPacks:PackIconMaterial Kind="LanguageMarkdown" Width="15" Height="15" />
+                                    </Setter.Value>
+                                </Setter>
+                            </DataTrigger>
+                            <DataTrigger Binding="{Binding IsMarkdownMode}" Value="False">
+                                <Setter Property="Content">
+                                    <Setter.Value>
+                                        <iconPacks:PackIconMaterial Kind="LanguageMarkdownOutline" Width="15" Height="15" />
+                                    </Setter.Value>
+                                </Setter>
+                            </DataTrigger>
+                        </Style.Triggers>
+                    </Style>
+                </Button.Style>
+
+               
+            </Button>
+
             <!--Message Text Box-->
             <extensions:MultiLineSendBox
-                Grid.Row="1" Grid.Column="1"
+                Grid.Row="1" Grid.Column="2"
                 Style="{StaticResource GroupMeClient.Wpf.Styles.SendTextBox}"
                 IsReadOnly="{Binding IsSending}"
                 extensions:FileDragDropPasteHelper.IsFileDragDropPasteEnabled="True"
@@ -407,7 +457,7 @@
             </extensions:MultiLineSendBox>
 
             <!--Plus Button-->
-            <Button Grid.Row="1" Grid.Column="2"
+            <Button Grid.Row="1" Grid.Column="3"
                     Style="{StaticResource bottomBarButtonStyle}"
                     Background="Transparent"
                     Margin="0,0,10,0"
@@ -417,7 +467,7 @@
             </Button>
 
             <!--Send Message Button-->
-            <Button Grid.Row="1" Grid.Column="3"
+            <Button Grid.Row="1" Grid.Column="4"
                     Style="{StaticResource bottomBarButtonStyle}"
                     Background="Transparent"
                     Margin="0,0,24,0"

--- a/GroupMeClient.WpfUI/Views/Controls/GroupContentsControl.xaml
+++ b/GroupMeClient.WpfUI/Views/Controls/GroupContentsControl.xaml
@@ -355,8 +355,8 @@
         <Grid Grid.Row="3"
               Background="{DynamicResource MahApps.Brushes.Control.Background}">
             <Grid.ColumnDefinitions>
-                <ColumnDefinition Width="40" />
-                <ColumnDefinition Width="20" />
+                <ColumnDefinition Width="35" />
+                <ColumnDefinition Width="18" />
                 <ColumnDefinition Width="*" />
                 <ColumnDefinition Width="Auto" />
                 <ColumnDefinition Width="Auto" />

--- a/GroupMeClient.WpfUI/Views/Controls/ViewReleaseNotesControl.xaml
+++ b/GroupMeClient.WpfUI/Views/Controls/ViewReleaseNotesControl.xaml
@@ -4,6 +4,7 @@
              xmlns:mc="http://schemas.openxmlformats.org/markup-compatibility/2006" 
              xmlns:d="http://schemas.microsoft.com/expression/blend/2008"
              xmlns:controls="http://metro.mahapps.com/winfx/xaml/controls" 
+             xmlns:extensions="clr-namespace:GroupMeClient.WpfUI.Extensions"
              mc:Ignorable="d" 
              d:DesignHeight="200" d:DesignWidth="200"
              Width="600"
@@ -19,7 +20,7 @@
                     <Expander Header="{Binding Version}" 
                               controls:ControlsHelper.ContentCharacterCasing="Normal"
                               IsExpanded="{Binding IsLatest, Mode=OneTime}">
-                        <TextBlock Text="{Binding ReleaseNotes}"
+                        <TextBlock extensions:TextBlockExtensions.InlineList="{Binding ReleaseNotes, Converter={StaticResource inlineConverter}, Mode=OneWay}"
                                    Focusable="False"
                                    IsHitTestVisible="False"
                                    TextWrapping="Wrap"/>


### PR DESCRIPTION
Adds support for sending and receiving messages with Markdown formatting.
Adds keyboard shortcuts to toggle Markdown mode (Ctrl-M), and to access the Message Effects button that was shifted to make room for the Markdown toggle (Ctrl-E).
Also adds Ctrl-R for refresh and Ctrl-W for closing the current chat.

Messages sent in Markdown format support most features of base Markdown, and some extensions like fenced code blocks.