### PR TITLE
MvvmLight Plugin Compatibility Support

### DIFF
--- a/GroupMeClient.WpfUI/GroupMeClient.WpfUI.csproj
+++ b/GroupMeClient.WpfUI/GroupMeClient.WpfUI.csproj
@@ -511,6 +511,9 @@
     <PackageReference Include="Microsoft.Xaml.Behaviors.Wpf">
       <Version>1.1.31</Version>
     </PackageReference>
+    <PackageReference Include="MvvmLightLibsStd10">
+      <Version>5.4.1.1</Version>
+    </PackageReference>
     <PackageReference Include="Neo.Markdig.Xaml">
       <Version>1.0.10</Version>
     </PackageReference>


### PR DESCRIPTION
Added MvvmLight back in as a dependency. Many existing plugins rely on MvvmLight being provided by GMDC and would break if MvvmLight was removed.

This will likely be removed in a future version as a breaking plugin API change.