### PR TITLE
NuGet Package Updates 8/29/21

### DIFF
--- a/GroupMeClient.Core/GroupMeClient.Core.csproj
+++ b/GroupMeClient.Core/GroupMeClient.Core.csproj
@@ -40,7 +40,7 @@
       <PrivateAssets>all</PrivateAssets>
       <IncludeAssets>runtime; build; native; contentfiles; analyzers; buildtransitive</IncludeAssets>
     </PackageReference>
-    <PackageReference Include="Microsoft.Toolkit.Mvvm" Version="7.0.1" />
+    <PackageReference Include="Microsoft.Toolkit.Mvvm" Version="7.0.2" />
     <PackageReference Include="NuGet.CommandLine" Version="5.10.0">
       <PrivateAssets>all</PrivateAssets>
       <IncludeAssets>runtime; build; native; contentfiles; analyzers; buildtransitive</IncludeAssets>

--- a/GroupMeClient.Core/GroupMeClient.Core.csproj
+++ b/GroupMeClient.Core/GroupMeClient.Core.csproj
@@ -32,11 +32,11 @@
     </PackageReference>
     <PackageReference Include="GroupMeClientApi" Version="1.1.1" />
     <PackageReference Include="GroupMeClientPlugin" Version="2.0.2" />
-    <PackageReference Include="Microsoft.EntityFrameworkCore.Sqlite" Version="3.1.13">
+    <PackageReference Include="Microsoft.EntityFrameworkCore.Sqlite" Version="3.1.18">
       <PrivateAssets>none</PrivateAssets>
       <ExcludeAssets>none</ExcludeAssets>
     </PackageReference>
-    <PackageReference Include="Microsoft.EntityFrameworkCore.Tools" Version="3.1.13">
+    <PackageReference Include="Microsoft.EntityFrameworkCore.Tools" Version="3.1.18">
       <PrivateAssets>all</PrivateAssets>
       <IncludeAssets>runtime; build; native; contentfiles; analyzers; buildtransitive</IncludeAssets>
     </PackageReference>

--- a/GroupMeClient.Core/GroupMeClient.Core.csproj
+++ b/GroupMeClient.Core/GroupMeClient.Core.csproj
@@ -41,7 +41,7 @@
       <IncludeAssets>runtime; build; native; contentfiles; analyzers; buildtransitive</IncludeAssets>
     </PackageReference>
     <PackageReference Include="Microsoft.Toolkit.Mvvm" Version="7.0.1" />
-    <PackageReference Include="NuGet.CommandLine" Version="5.8.1">
+    <PackageReference Include="NuGet.CommandLine" Version="5.10.0">
       <PrivateAssets>all</PrivateAssets>
       <IncludeAssets>runtime; build; native; contentfiles; analyzers; buildtransitive</IncludeAssets>
     </PackageReference>

--- a/GroupMeClient.Core/GroupMeClient.Core.csproj
+++ b/GroupMeClient.Core/GroupMeClient.Core.csproj
@@ -25,7 +25,7 @@
   </PropertyGroup>
   
   <ItemGroup>
-    <PackageReference Include="DynamicData" Version="7.1.1" />
+    <PackageReference Include="DynamicData" Version="7.3.1" />
     <PackageReference Include="GitInfo" Version="2.0.26">
       <PrivateAssets>all</PrivateAssets>
       <IncludeAssets>runtime; build; native; contentfiles; analyzers; buildtransitive</IncludeAssets>
@@ -46,7 +46,7 @@
       <IncludeAssets>runtime; build; native; contentfiles; analyzers; buildtransitive</IncludeAssets>
     </PackageReference>
     <PackageReference Include="Octokit" Version="0.50.0" />
-    <PackageReference Include="ReactiveUI" Version="13.2.2" />
+    <PackageReference Include="ReactiveUI" Version="16.2.1" />
     <PackageReference Include="SQLitePCLRaw.bundle_e_sqlite3" Version="2.0.4" />
     <PackageReference Include="StyleCop.Analyzers" Version="1.1.118">
       <PrivateAssets>all</PrivateAssets>

--- a/GroupMeClient.Core/GroupMeClient.Core.csproj
+++ b/GroupMeClient.Core/GroupMeClient.Core.csproj
@@ -26,7 +26,7 @@
   
   <ItemGroup>
     <PackageReference Include="DynamicData" Version="7.3.1" />
-    <PackageReference Include="GitInfo" Version="2.0.26">
+    <PackageReference Include="GitInfo" Version="2.2.0">
       <PrivateAssets>all</PrivateAssets>
       <IncludeAssets>runtime; build; native; contentfiles; analyzers; buildtransitive</IncludeAssets>
     </PackageReference>

--- a/GroupMeClient.WpfUI/GroupMeClient.WpfUI.csproj
+++ b/GroupMeClient.WpfUI/GroupMeClient.WpfUI.csproj
@@ -532,7 +532,7 @@
       <Version>1.0.0</Version>
     </PackageReference>
     <PackageReference Include="ReactiveUI.WPF">
-      <Version>13.2.2</Version>
+      <Version>16.2.1</Version>
     </PackageReference>
     <PackageReference Include="Squirrel.Windows">
       <Version>1.9.1</Version>

--- a/GroupMeClient.WpfUI/GroupMeClient.WpfUI.csproj
+++ b/GroupMeClient.WpfUI/GroupMeClient.WpfUI.csproj
@@ -474,7 +474,7 @@
   </ItemGroup>
   <ItemGroup>
     <PackageReference Include="MahApps.Metro">
-      <Version>2.4.4</Version>
+      <Version>2.4.7</Version>
     </PackageReference>
     <PackageReference Include="MahApps.Metro.IconPacks.Entypo">
       <Version>4.8.0</Version>
@@ -543,7 +543,7 @@
       <PrivateAssets>all</PrivateAssets>
     </PackageReference>
     <PackageReference Include="VirtualizingWrapPanel">
-      <Version>1.5.3</Version>
+      <Version>1.5.4</Version>
     </PackageReference>
     <PackageReference Include="XamlAnimatedGif">
       <Version>1.2.3</Version>

--- a/GroupMeClient.WpfUI/GroupMeClient.WpfUI.csproj
+++ b/GroupMeClient.WpfUI/GroupMeClient.WpfUI.csproj
@@ -492,7 +492,7 @@
       <Version>0.25.0</Version>
     </PackageReference>
     <PackageReference Include="Microsoft.Extensions.DependencyInjection">
-      <Version>5.0.1</Version>
+      <Version>5.0.2</Version>
     </PackageReference>
     <PackageReference Include="Microsoft.Extensions.Hosting">
       <Version>5.0.0</Version>

--- a/GroupMeClient.WpfUI/GroupMeClient.WpfUI.csproj
+++ b/GroupMeClient.WpfUI/GroupMeClient.WpfUI.csproj
@@ -498,7 +498,7 @@
       <Version>5.0.0</Version>
     </PackageReference>
     <PackageReference Include="Microsoft.Toolkit.Uwp.Notifications">
-      <Version>6.1.0</Version>
+      <Version>7.0.2</Version>
     </PackageReference>
     <PackageReference Include="Microsoft.Windows.SDK.Contracts">
       <Version>10.0.19041.1</Version>
@@ -518,7 +518,7 @@
       <Version>1.0.10</Version>
     </PackageReference>
     <PackageReference Include="Notification.WPF">
-      <Version>2.0.0.8</Version>
+      <Version>5.1.1.1</Version>
     </PackageReference>
     <PackageReference Include="NuGet.CommandLine">
       <Version>5.10.0</Version>

--- a/GroupMeClient.WpfUI/GroupMeClient.WpfUI.csproj
+++ b/GroupMeClient.WpfUI/GroupMeClient.WpfUI.csproj
@@ -489,7 +489,7 @@
       <Version>4.8.0</Version>
     </PackageReference>
     <PackageReference Include="Markdig">
-      <Version>0.25.0</Version>
+      <Version>0.26.0</Version>
     </PackageReference>
     <PackageReference Include="Microsoft.Extensions.DependencyInjection">
       <Version>5.0.2</Version>

--- a/GroupMeClient.WpfUI/GroupMeClient.WpfUI.csproj
+++ b/GroupMeClient.WpfUI/GroupMeClient.WpfUI.csproj
@@ -504,7 +504,7 @@
       <Version>10.0.19041.1</Version>
     </PackageReference>
     <PackageReference Include="Microsoft.EntityFrameworkCore.Design">
-      <Version>3.1.13</Version>
+      <Version>3.1.18</Version>
       <IncludeAssets>runtime; build; native; contentfiles; analyzers; buildtransitive</IncludeAssets>
       <PrivateAssets>all</PrivateAssets>
     </PackageReference>
@@ -521,7 +521,7 @@
       <Version>2.0.0.8</Version>
     </PackageReference>
     <PackageReference Include="NuGet.CommandLine">
-      <Version>5.8.1</Version>
+      <Version>5.10.0</Version>
       <IncludeAssets>runtime; build; native; contentfiles; analyzers; buildtransitive</IncludeAssets>
       <PrivateAssets>all</PrivateAssets>
     </PackageReference>

--- a/GroupMeClient.WpfUI/Notifications/Display/Win7/SingularNotificationManager.cs
+++ b/GroupMeClient.WpfUI/Notifications/Display/Win7/SingularNotificationManager.cs
@@ -82,7 +82,7 @@ namespace GroupMeClient.WpfUI.Notifications.Display.Win7
         }
 
         /// <inheritdoc/>
-        public void ShowProgressBar(out ProgressFinaly<(int? value, string message, string title, bool? showCancel)> progress, out CancellationToken Cancel, string Title = null, bool ShowCancelButton = true, bool ShowProgress = true, string areaName = "", bool TrimText = false, uint DefaultRowsCount = 1, string BaseWaitingMessage = "Calculation time")
+        public NotifierProgress<(double? value, string message, string title, bool? showCancel)> ShowProgressBar(string Title = null, bool ShowCancelButton = true, bool ShowProgress = true, string areaName = "", bool TrimText = false, uint DefaultRowsCount = 1, string BaseWaitingMessage = "Calculation time")
         {
             throw new NotImplementedException();
         }


### PR DESCRIPTION
- Updated EF Core
- Updated Mvvm Toolkit and Microsoft DI toolkit
- Updated WPF UI components: MahApps Metro, VirtualizingWrapPanel
- Updated notification components; UWP Toolkit and WPF emulated notifications
- Updated ReactiveUI and DynamicData
- Updated GitInfo, Markdig, and NuGet CLI

XamlAnimatedGif cannot be updated at this time due to breakage in plugins depending on v1.x.
SQLite cannot be updated due to issues with native assets in AnyCPU mode in v2.0.5.
Waiting to update Squirrel until update system is entirely revamped in response to  #147. Now that Squirrel 2 is released, the compatibility issues can be avoided.
