### PR TITLE
Feature/fix for NuGet CLI v5

### DIFF
--- a/GroupMeClient.Core/Services/ReleaseInfo.cs
+++ b/GroupMeClient.Core/Services/ReleaseInfo.cs
@@ -1,7 +1,7 @@
-﻿using GroupMeClient.Core.Controls.Documents;
-using System;
+﻿using System;
 using System.Collections.Generic;
 using System.Text;
+using GroupMeClient.Core.Controls.Documents;
 
 namespace GroupMeClient.Core.Services
 {

--- a/GroupMeClient.WpfUI/GroupMeClient.nuspec
+++ b/GroupMeClient.WpfUI/GroupMeClient.nuspec
@@ -12,7 +12,6 @@
     <dependencies />
   </metadata>
   <files>
-    <file src="*.*" target="lib\net45\" exclude="*.pdb;*.nupkg;*.vshost.*"/>
     <file src="**\*.*" target="lib\net45\" exclude="*.pdb;*.nupkg;*.vshost.*"/>
   </files>
 </package>


### PR DESCRIPTION
Resolved a warning when building the installer using NuGet CLI tools v5.0 and newer